### PR TITLE
Fix bug in SimpleImputer for determining image columns

### DIFF
--- a/datawig/simple_imputer.py
+++ b/datawig/simple_imputer.py
@@ -124,7 +124,7 @@ class SimpleImputer():
         valid_ext = ['.jpg', '.png', '.gif']
 
         for col in other_cols:
-            if os.path.exists(data_frame[col].values[1]) and any(
+            if os.path.exists(str(data_frame[col].values[1])) and any(
                     x in data_frame[col].values[1] for x in valid_ext):
                 image_cols.append(col)
             else:


### PR DESCRIPTION
**Description of changes:**

- SimpleImputer throws an error when it gets a nan by chance as an argument into the `os.path.exists()` method for determining if a column contains image data. This fixes that by applying `str()` before checking if the path exists.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
