### PR TITLE
Fix bug in params tutorial for examples

### DIFF
--- a/examples/params_tutorial/params_tutorial.py
+++ b/examples/params_tutorial/params_tutorial.py
@@ -120,7 +120,9 @@ color_labels = [random.choice(colors) for _ in range(n_samples)]
 df = pd.DataFrame({"image_files": color_labels,
                    "label": color_labels})
 
-df['image_files'] = os.path.join(img_path, df['image_files'] + ".png")
+for index, row in df.iterrows():
+    row['image_files'] = os.path.join(img_path, row['image_files'] + ".png")
+    
 df_train, df_test = random_split(df, split_ratios=[0.8, 0.2])
 
 #Fit a model with HPO


### PR DESCRIPTION
Examples were not running properly due to same bug with joining paths for synthetic data as happened in the test cases. Fixed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
