### PR TITLE
Add multi-gpu support for imputation models.

### DIFF
--- a/datawig/imputer.py
+++ b/datawig/imputer.py
@@ -172,8 +172,7 @@ class Imputer:
     def fit(self,
             train_df: pd.DataFrame,
             test_df: pd.DataFrame = None,
-            ctx: mx.context = mx.gpu() if gpu_device() else mx.cpu(),
-            num_gpus: int = 1,
+            ctx: mx.context = gpu_device(),
             learning_rate: float = 1e-3,
             num_epochs: int = 100,
             patience: int = 3,
@@ -188,7 +187,8 @@ class Imputer:
         :param train_df: training data as dataframe
         :param test_df: test data as dataframe; if not provided, [test_split] % of the training
                         data are used as test data
-        :param ctx: mxnet context (default mx.cpu())
+        :param ctx: List of mxnet contexts (if no gpu's available, defaults to [mx.cpu()])
+                    User can also pass in a list gpus to be used, ex. [mx.gpu(0), mx.gpu(2), mx.gpu(4)]
         :param learning_rate: learning rate for stochastic gradient descent (default 1e-4)
         :param num_epochs: maximal number of training epochs (default 100)
         :param patience: used for early stopping; after [patience] epochs with no improvement,
@@ -210,17 +210,7 @@ class Imputer:
         self.batch_size = batch_size
         self.final_fc_hidden_units = final_fc_hidden_units
 
-        gpu_list = []
-        if num_gpus > 1:
-            for i in range(num_gpus):
-                gpu_ctx = gpu_device(gpu_number=i)
-                if gpu_ctx is not None:
-                    gpu_list.append(gpu_ctx)
-        
-        if len(gpu_list) == 0:
-            gpu_list.append(ctx)
-
-        self.ctx = gpu_list
+        self.ctx = ctx
 
         if (train_df is None) or (not isinstance(train_df, pd.core.frame.DataFrame)):
             raise ValueError("Need a non-empty DataFrame for fitting Imputer model")

--- a/datawig/imputer.py
+++ b/datawig/imputer.py
@@ -173,6 +173,7 @@ class Imputer:
             train_df: pd.DataFrame,
             test_df: pd.DataFrame = None,
             ctx: mx.context = mx.gpu() if gpu_device() else mx.cpu(),
+            num_gpus: int = 1,
             learning_rate: float = 1e-3,
             num_epochs: int = 100,
             patience: int = 3,
@@ -209,7 +210,17 @@ class Imputer:
         self.batch_size = batch_size
         self.final_fc_hidden_units = final_fc_hidden_units
 
-        self.ctx = ctx
+        gpu_list = []
+        if num_gpus > 1:
+            for i in range(num_gpus):
+                gpu_ctx = gpu_device(gpu_number=i)
+                if gpu_ctx is not None:
+                    gpu_list.append(gpu_ctx)
+        
+        if len(gpu_list) == 0:
+            gpu_list.append(ctx)
+
+        self.ctx = gpu_list
 
         if (train_df is None) or (not isinstance(train_df, pd.core.frame.DataFrame)):
             raise ValueError("Need a non-empty DataFrame for fitting Imputer model")

--- a/datawig/simple_imputer.py
+++ b/datawig/simple_imputer.py
@@ -151,8 +151,7 @@ class SimpleImputer():
     def fit_hpo(self,
                 train_df: pd.DataFrame,
                 test_df: pd.DataFrame = None,
-                ctx: mx.context = mx.gpu() if gpu_device() else mx.cpu(),
-                num_gpus: int = 1,
+                ctx: mx.context = gpu_device(),
                 learning_rate: float = 1e-3,
                 num_epochs: int = 10,
                 patience: int = 3,
@@ -178,7 +177,8 @@ class SimpleImputer():
         :param train_df: training data as dataframe
         :param test_df: test data as dataframe; if not provided, a ratio of test_split of the
                             training data are used as test data
-        :param ctx: mxnet context (default mx.cpu())
+        :param ctx: List of mxnet contexts (if no gpu's available, defaults to [mx.cpu()])
+                    User can also pass in a list gpus to be used, ex. [mx.gpu(0), mx.gpu(2), mx.gpu(4)]
         :param learning_rate: learning rate for stochastic gradient descent (default 4e-4)
         :param num_epochs: maximal number of training epochs (default 10)
         :param patience: used for early stopping; after [patience] epochs with no improvement,
@@ -320,7 +320,6 @@ class SimpleImputer():
                     .fit(train_df_hpo.copy(),
                          None,
                          ctx,
-                         num_gpus,
                          learning_rate,
                          num_epochs,
                          patience,
@@ -336,7 +335,6 @@ class SimpleImputer():
                     .fit(train_df_hpo.copy(),
                          None,
                          ctx,
-                         num_gpus,
                          hyper_param['learning_rate'],
                          num_epochs,
                          patience,
@@ -407,12 +405,12 @@ class SimpleImputer():
 
         # Create and fit imputer with best HPs
         if len(self.image_columns) > 0:
-            self.imputer = self.imputer.fit(train_df, test_df, ctx, num_gpus, learning_rate, num_epochs,
+            self.imputer = self.imputer.fit(train_df, test_df, ctx, learning_rate, num_epochs,
                                             patience, test_split,
                                             best_hps['weight_decay'], batch_size,
                                             best_hps['final_fc_dim'])
         else:
-            self.imputer = self.imputer.fit(train_df, test_df, ctx, num_gpus, learning_rate, num_epochs,
+            self.imputer = self.imputer.fit(train_df, test_df, ctx, learning_rate, num_epochs,
                                             patience, test_split, weight_decay[0])
 
         self.hpo_results = hpo_results
@@ -424,8 +422,7 @@ class SimpleImputer():
     def fit(self,
             train_df: pd.DataFrame,
             test_df: pd.DataFrame = None,
-            ctx: mx.context = mx.gpu() if gpu_device() else mx.cpu(),
-            num_gpus: int = 1,
+            ctx: mx.context = gpu_device(),
             learning_rate: float = 4e-3,
             num_epochs: int = 10,
             patience: int = 3,
@@ -442,7 +439,8 @@ class SimpleImputer():
         :param train_df: training data as dataframe
         :param test_df: test data as dataframe; if not provided, a ratio of test_split of the
                             training data are used as test data
-        :param ctx: mxnet context (default mx.gpu() if available, otherwise mx.cpu())
+        :param ctx: List of mxnet contexts (if no gpu's available, defaults to [mx.cpu()])
+                    User can also pass in a list gpus to be used, ex. [mx.gpu(0), mx.gpu(2), mx.gpu(4)]
         :param learning_rate: learning rate for stochastic gradient descent (default 4e-4)
         :param num_epochs: maximal number of training epochs (default 10)
         :param patience: used for early stopping; after [patience] epochs with no improvement,
@@ -508,7 +506,7 @@ class SimpleImputer():
 
         self.output_path = self.imputer.output_path
 
-        self.imputer = self.imputer.fit(train_df, test_df, ctx, num_gpus, learning_rate, num_epochs, patience,
+        self.imputer = self.imputer.fit(train_df, test_df, ctx, learning_rate, num_epochs, patience,
                                         test_split,
                                         weight_decay, batch_size,
                                         final_fc_hidden_units=final_fc_hidden_units,

--- a/datawig/simple_imputer.py
+++ b/datawig/simple_imputer.py
@@ -152,6 +152,7 @@ class SimpleImputer():
                 train_df: pd.DataFrame,
                 test_df: pd.DataFrame = None,
                 ctx: mx.context = mx.gpu() if gpu_device() else mx.cpu(),
+                num_gpus: int = 1,
                 learning_rate: float = 1e-3,
                 num_epochs: int = 10,
                 patience: int = 3,
@@ -319,6 +320,7 @@ class SimpleImputer():
                     .fit(train_df_hpo.copy(),
                          None,
                          ctx,
+                         num_gpus,
                          learning_rate,
                          num_epochs,
                          patience,
@@ -334,6 +336,7 @@ class SimpleImputer():
                     .fit(train_df_hpo.copy(),
                          None,
                          ctx,
+                         num_gpus,
                          hyper_param['learning_rate'],
                          num_epochs,
                          patience,
@@ -404,12 +407,12 @@ class SimpleImputer():
 
         # Create and fit imputer with best HPs
         if len(self.image_columns) > 0:
-            self.imputer = self.imputer.fit(train_df, test_df, ctx, learning_rate, num_epochs,
+            self.imputer = self.imputer.fit(train_df, test_df, ctx, num_gpus, learning_rate, num_epochs,
                                             patience, test_split,
                                             best_hps['weight_decay'], batch_size,
                                             best_hps['final_fc_dim'])
         else:
-            self.imputer = self.imputer.fit(train_df, test_df, ctx, learning_rate, num_epochs,
+            self.imputer = self.imputer.fit(train_df, test_df, ctx, num_gpus, learning_rate, num_epochs,
                                             patience, test_split, weight_decay[0])
 
         self.hpo_results = hpo_results
@@ -422,6 +425,7 @@ class SimpleImputer():
             train_df: pd.DataFrame,
             test_df: pd.DataFrame = None,
             ctx: mx.context = mx.gpu() if gpu_device() else mx.cpu(),
+            num_gpus: int = 1,
             learning_rate: float = 4e-3,
             num_epochs: int = 10,
             patience: int = 3,
@@ -504,7 +508,7 @@ class SimpleImputer():
 
         self.output_path = self.imputer.output_path
 
-        self.imputer = self.imputer.fit(train_df, test_df, ctx, learning_rate, num_epochs, patience,
+        self.imputer = self.imputer.fit(train_df, test_df, ctx, num_gpus, learning_rate, num_epochs, patience,
                                         test_split,
                                         weight_decay, batch_size,
                                         final_fc_hidden_units=final_fc_hidden_units,

--- a/datawig/utils.py
+++ b/datawig/utils.py
@@ -65,22 +65,42 @@ def merge_dicts(d1: dict, d2: dict):
     """
     return dict(itertools.chain(d1.items(), d2.items()))
 
-def gpu_device(gpu_number: int = 0) -> mx.context:
+def gpu_device() -> mx.context:
     """
 
-    Returns the gpu context for a given gpu device or None if that context is not available.
-    Use it for auto-detecting whether a gpu is available on a machine with
-    ctx = mx.gpu() if gpu_device() else mx.cpu()
+    Returns the a list of all available gpu contexts for a given machine.
+    If no gpus are available, returns [mx.cpu()].
+    Use it to automatically return MxNet contexts (uses max number of gpus or cpu)
 
-    :param gpu_number: number of the gpu, default 0
-    :return: mxnet context of a gpu or none if not available
+    :return: List of mxnet contexts of a gpu or [mx.cpu()] if gpu not available
 
     """
-    try:
-        _ = mx.nd.array([1, 2, 3], ctx=mx.gpu(gpu_number))
-    except mx.MXNetError:
-        return None
-    return mx.gpu(gpu_number)
+    gpu_list = []
+    for gpu_number in range(16):
+        try:
+            _ = mx.nd.array([1, 2, 3], ctx=mx.gpu(gpu_number))
+            gpu_list.append(mx.gpu(gpu_number))
+        except mx.MXNetError:
+            pass
+    
+    if len(gpu_list) == 0:
+        gpu_list.append(mx.cpu())
+
+    return gpu_list
+
+# def gpu_device(gpu_number: int = 0) -> mx.context:
+#     """
+#     Returns the gpu context for a given gpu device or None if that context is not available.
+#     Use it for auto-detecting whether a gpu is available on a machine with
+#     ctx = mx.gpu() if gpu_device() else mx.cpu()
+#     :param gpu_number: number of the gpu, default 0
+#     :return: mxnet context of a gpu or none if not available
+#     """
+#     try:
+#         _ = mx.nd.array([1, 2, 3], ctx=mx.gpu(gpu_number))
+#     except mx.MXNetError:
+#         return None
+#     return mx.gpu(gpu_number)
 
 def random_split(data_frame: pd.DataFrame,
                  split_ratios: List[float] = None,


### PR DESCRIPTION
Made use of the functionality of the MxNet Module API to enable multi-gpu support, a feature that can signifincantly speed up training for models with images.

Ran a small set of experiments with images, and as expected, we can get more than 2x improvements in training speed by doubling/tripling the number of gpu's.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
