### PR TITLE
Make computation of class patterns robust

### DIFF
--- a/datawig/imputer.py
+++ b/datawig/imputer.py
@@ -300,7 +300,7 @@ class Imputer:
         for feature_matrix_scaled, encoder in zip(X_scaled, explainable_data_encoders):
             if isinstance(encoder, TfIdfEncoder):
                 # project features onto labels and sum across items
-                class_patterns.append((encoder, feature_matrix_scaled.dot(p_normalized)))
+                class_patterns.append((encoder, feature_matrix_scaled[:, :p_normalized.shape[0]].dot(p_normalized)))
             elif isinstance(encoder, CategoricalEncoder):
                 # compute mean class output for all input labels
                 class_patterns.append((encoder, np.array(

--- a/datawig/imputer.py
+++ b/datawig/imputer.py
@@ -300,6 +300,8 @@ class Imputer:
         for feature_matrix_scaled, encoder in zip(X_scaled, explainable_data_encoders):
             if isinstance(encoder, TfIdfEncoder):
                 # project features onto labels and sum across items
+                # We need to limit the columns of feature matrix scaled, such that its number modulo batch size is zero.
+                # See also .start_padding in iterators.py.
                 class_patterns.append((encoder, feature_matrix_scaled[:, :p_normalized.shape[0]].dot(p_normalized)))
             elif isinstance(encoder, CategoricalEncoder):
                 # compute mean class output for all input labels

--- a/datawig/imputer.py
+++ b/datawig/imputer.py
@@ -28,12 +28,14 @@ from typing import Any, List, Tuple
 
 import mxnet as mx
 import numpy as np
+
 import pandas as pd
 from mxnet.callback import save_checkpoint
+from sklearn.preprocessing import StandardScaler
 
 from . import calibration
 from .column_encoders import (CategoricalEncoder, ColumnEncoder,
-                              NumericalEncoder)
+                              NumericalEncoder, TfIdfEncoder)
 from .evaluation import evaluate_and_persist_metrics
 from .iterators import ImputerIterDf
 from .mxnet_input_symbols import Featurizer
@@ -84,6 +86,13 @@ class Imputer:
 
         self.precision_recall_curves = {}
         self.calibration_info = {}
+
+        self.__class_patterns = None
+        # explainability only works for Categorical and Tfidf inputs with a single categorical output column
+        self.is_explainable = np.any([isinstance(encoder, CategoricalEncoder) or isinstance(encoder, TfIdfEncoder)
+                                      for encoder in self.data_encoders]) and \
+                              (len(self.label_encoders) == 1) and \
+                              (isinstance(self.label_encoders[0], CategoricalEncoder))
 
         if len(self.data_featurizers) != len(self.data_encoders):
             raise ValueError("Argument Number of data_featurizers ({}) \
@@ -244,7 +253,165 @@ class Imputer:
         self.__prune_models()
         self.save()
 
+        if self.is_explainable:
+            self.__persist_class_prototypes(iter_train, train_df)
+
         return self
+
+
+    def __persist_class_prototypes(self, iter_train, train_df):
+        """
+        Save mean feature pattern as self.__class_patterns for each label_encoder, for each label, for each data encoder,
+        given by the projection of the feature matrix (items by ngrams/categories)
+        onto the softmax outputs (items by labels).
+        self.__class_patterns is a list of tuples of the form (column_encoder, feature-label-correlation-matrix).
+        """
+
+        if len(self.label_encoders) > 1:
+            logger.warn('Persisting class prototypes works only for a single output column. '
+                        'Choosing ' + str(self.label_encoders[0].output_column) + '.')
+        label_name = self.label_encoders[0].output_column
+
+        iter_train.reset()
+        p = self.__predict_mxnet_iter(iter_train)[label_name]  # class probabilities for every item (items x labels)
+
+        # center and whiten the class probabilities
+        p_normalized = StandardScaler().fit_transform(p)
+
+        # Generate list of data encoders, with features suitable for explanation. Only TfIDf and Categorical supported.
+        explainable_data_encoders = []
+        explainable_data_encoders_idx = []
+        for encoder_idx, encoder in enumerate(self.data_encoders):
+            if not (isinstance(encoder, TfIdfEncoder) or isinstance(encoder, CategoricalEncoder)):
+                logger.warn("Data encoder type {} incompatible for explaining classes".format(type(encoder)))
+            else:
+                explainable_data_encoders.append(encoder)
+                explainable_data_encoders_idx.append(encoder_idx)
+
+        # encoded representations of training data ([items x features] for every encoded column.)
+        X = [enc.transform(train_df).transpose() for enc in explainable_data_encoders]
+
+        # whiten the feature matrix. Centering is not supported for sparse matrices.
+        # Doesn't do anything for categorical data where the shape is (1, num_items)
+        X_scaled = [StandardScaler(with_mean=False).fit_transform(feature_matrix) for feature_matrix in X]
+
+        # compute correlation between features and labels
+        class_patterns = []
+        for feature_matrix_scaled, encoder in zip(X_scaled, explainable_data_encoders):
+            if isinstance(encoder, TfIdfEncoder):
+                # project features onto labels and sum across items
+                class_patterns.append((encoder, feature_matrix_scaled.dot(p_normalized)))
+            elif isinstance(encoder, CategoricalEncoder):
+                # compute mean class output for all input labels
+                class_patterns.append((encoder, np.array(
+                        [np.sum(p_normalized[np.where(feature_matrix_scaled[0, :] == category)[0], :], axis=0)
+                         for category in encoder.idx_to_token.keys()])))
+            else:
+                logger.warn("column encoder not supported for explain.")
+
+        self.__class_patterns = class_patterns
+
+    def __get_label_encoder(self, label_column: str = None):
+        """
+        Given the name of an output column return the corresponding column encoder. Default to first available
+
+        :param label_column: column name for which to return encoder.
+        :return: column_encoder
+        """
+
+        if label_column is not None:
+            label_encoders = [enc for enc in self.label_encoders if enc.output_column == label_column]
+            if len(label_encoders) == 0:
+                raise ValueError("Could not find label column")
+            else:
+                label_encoder = label_encoders[0]
+        else:
+            label_encoder = self.label_encoders[0]
+
+        return label_encoder
+
+    def explain(self, label: str, k: int = 10, label_column: str = None):
+        """
+        Return dictionary with entries for each explainable input column,
+        returning top k tokens with highest correlation to label.
+
+        :param label: label value to explain
+        :param k: number of explanations for each input encoder to return. If not given, return top 10 explanations.
+        :param label_column: name of label column to be explained (optional, defaults to the first available column.)
+        """
+
+        if not self.is_explainable:
+            raise ValueError("No explainable data encoders available.")
+
+        label_encoder = self.__get_label_encoder(label_column)
+
+        # Check whether to-be-explained label value exists.
+        if label not in label_encoder.token_to_idx.keys():
+            raise ValueError("Specified label {} not observed in label encoder".format(label))
+
+        # assign index of label value (there can be an additional label column for "unobserved" label.
+        label_idx = label_encoder.token_to_idx[label]
+
+        # for each data encoder extract (token_idx, token_idx_correlation_with_label), extract and apply idx2token map.
+        token_weights = {}
+        for encoder, pattern in self.__class_patterns:
+            # extract idx2token mappings
+            if isinstance(encoder, CategoricalEncoder):
+                idx_tuples = zip(pattern[:, label_idx].argsort()[::-1][:k], sorted(pattern[:, label_idx])[::-1][:k])
+                keymap = {i+1: i for i in range(len(encoder.idx_to_token))}
+                idx2token_temp = dict((keymap[key], val) for key, val in encoder.idx_to_token.items())
+            if isinstance(encoder, TfIdfEncoder):
+                idx_tuples = zip(pattern[:, label_idx].argsort()[::-1][:k], sorted(pattern[:, label_idx])[::-1][:k])
+                idx2token_temp = encoder.idx_to_token
+            token_weights[encoder.output_column] = [(idx2token_temp[token], weight) for token, weight in idx_tuples]
+
+        return token_weights
+
+
+    def explain_instance(self, instance: pd.core.series.Series, k: int = 10, label_column: str = None) -> dict:
+        """
+        Return dictionary with entries for each explainable input column of the given instance.
+        Each entry shows the most likely class label for the input and the features with the highest correlation
+        with that class.
+
+        :param instance: row of data frame (or dictionary)
+        :param k: number of explanations (ngrams) for text inputs
+        :param label_column: name of label column to be explained (optional)
+        """
+
+        label_encoder = self.__get_label_encoder(label_column)
+
+        # encode instance columns
+        feature_tuples = {}
+        for encoder, pattern in self.__class_patterns:
+
+            token = instance[encoder.output_column]  # original input
+            feature_tuples[encoder.output_column] = {}
+
+            if isinstance(encoder, TfIdfEncoder):
+                input_encoded = encoder.vectorizer.transform([token]).todense()  # encode
+                projection = input_encoded.dot(pattern)  # project input onto prototypes
+                top_label_idx = np.argmax(projection)
+                feature_weights = np.multiply(pattern[:, top_label_idx], input_encoded) # correlation of label/feature
+                ordered_feature_idx = np.argsort(np.multiply(pattern[:, top_label_idx], input_encoded))
+                ordered_feature_idx = ordered_feature_idx.tolist()[0][::-1]
+
+                feature_tuples[encoder.output_column]['top_class'] = label_encoder.idx_to_token[top_label_idx]
+                feature_tuples[encoder.output_column]['token_weights'] =\
+                    [(encoder.idx_to_token[idx], feature_weights[0, idx]) for idx in ordered_feature_idx[:k]]
+
+            elif isinstance(encoder, CategoricalEncoder):
+                input_encoded = encoder.token_to_idx[token] - 1  # starts counting at 1
+                class_weights = pattern[input_encoded]  # correlation of input class with output classes
+                top_class_idx = np.argmax(class_weights)
+                top_class = label_encoder.idx_to_token[top_class_idx]
+                top_class_weight = pattern[input_encoded, top_class_idx]
+
+                feature_tuples[encoder.output_column]['top_class'] = top_class
+                feature_tuples[encoder.output_column]['token_weights'] = [(token, top_class_weight)]
+
+        return feature_tuples
+
 
     def __fit_module(self,
                      iter_train: ImputerIterDf,

--- a/test/test_explain.py
+++ b/test/test_explain.py
@@ -1,0 +1,97 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not
+# use this file except in compliance with the License. A copy of the License
+# is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+"""
+
+DataWig tests for explaining predictions
+
+"""
+
+import os
+import datawig
+from datawig.utils import random_split
+from datawig.utils import logger
+import pandas as pd
+import numpy as np
+from sklearn.metrics import precision_score
+from datawig import Imputer
+logger.setLevel("DEBUG")
+
+
+def test_explain_method_synthetic(test_dir):
+
+    # Generate simulated data for testing explain method
+    # Predict output column with entries in ['foo', 'bar'] from two columns, one
+    # categorical in ['foo', 'dummy'], one text in ['text_foo_text', 'text_dummy_text'].
+    # the output column is deterministically 'foo', if 'foo' occurs anywhere in any input column.
+    N = 100
+    cat_in_col = ['foo' if r > (1 / 2) else 'dummy' for r in np.random.rand(N)]
+    text_in_col = ['fff' if r > (1 / 2) else 'ddd' for r in np.random.rand(N)]
+    hash_in_col = ['h' for r in range(N)]
+    cat_out_col = ['foo' if 'f' in input[0] + input[1] else 'bar' for input in zip(cat_in_col, text_in_col)]
+
+    df = pd.DataFrame()
+    df['in_cat'] = cat_in_col
+    df['in_text'] = text_in_col
+    df['in_text_hash'] = hash_in_col
+    df['out_cat'] = cat_out_col
+
+    # Specify encoders and featurizers #
+    data_encoder_cols = [datawig.column_encoders.TfIdfEncoder('in_text', tokens="chars"),
+                         datawig.column_encoders.CategoricalEncoder('in_cat', max_tokens=1e1),
+                         datawig.column_encoders.BowEncoder('in_text_hash', tokens="chars")]
+    data_featurizer_cols = [datawig.mxnet_input_symbols.BowFeaturizer('in_text'),
+                            datawig.mxnet_input_symbols.EmbeddingFeaturizer('in_cat'),
+                            datawig.mxnet_input_symbols.BowFeaturizer('in_text_hash')]
+
+    label_encoder_cols = [datawig.column_encoders.CategoricalEncoder('out_cat')]
+
+    # Specify model
+    imputer = datawig.Imputer(
+       data_featurizers=data_featurizer_cols,
+       label_encoders=label_encoder_cols,
+       data_encoders=data_encoder_cols,
+       output_path=os.path.join(test_dir, "tmp", "explanation_tests")
+       )
+
+    # Train
+    tr, te = random_split(df.sample(90), [.8, .2])
+    imputer.fit(train_df=tr, test_df=te, num_epochs=10, learning_rate = 1e-2)
+    imputer.predict(te)
+
+    # Evaluate
+    assert precision_score(te.out_cat, te.out_cat_imputed, average='weighted') > .99
+
+    # assert item explanation, iterate over some inputs
+    for i in np.random.choice(N, 10):
+        text_explain = imputer.explain_instance(df.iloc[i])['in_text']
+        cat_explain = imputer.explain_instance(df.iloc[i])['in_cat']
+
+        if text_explain['top_class'] == 'bar':
+            assert text_explain['token_weights'][0][0] == 'd'
+        elif text_explain['top_class'] == 'foo':
+            assert text_explain['token_weights'][0][0] == 'f'
+
+        if cat_explain['top_class'] == 'bar':
+            assert cat_explain['token_weights'][0][0] == 'dummy'
+        elif cat_explain['top_class'] == 'foo':
+            assert cat_explain['token_weights'][0][0] == 'foo'
+
+    # assert class explanations
+    assert np.all(['f' in token for token, weight in imputer.explain('foo')['in_text']][:3])
+    assert ['f' in token for token, weight in imputer.explain('foo')['in_cat']][0]
+
+    # test serialisation to disk
+    imputer.save()
+    imputer_from_disk = Imputer.load(imputer.output_path)
+    assert np.all(['f' in token for token, weight in imputer_from_disk.explain('foo')['in_text']][:3])


### PR DESCRIPTION
Make computation of class patterns robust to truncaction of the predicitions from mxnet iterator. This is a known problem in imputer.__predict_mxnet_iter.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
