### PR TITLE
Tammruka/referential transparency

### DIFF
--- a/datawig/imputer.py
+++ b/datawig/imputer.py
@@ -740,7 +740,8 @@ class Imputer:
                 data_frame: pd.DataFrame,
                 precision_threshold: float = 0.0,
                 imputation_suffix: str = "_imputed",
-                score_suffix: str = "_imputed_proba") -> pd.DataFrame:
+                score_suffix: str = "_imputed_proba",
+                inplace: bool = False) -> pd.DataFrame:
         """
         Computes imputations for numerical or categorical values
 
@@ -760,8 +761,13 @@ class Imputer:
                                     imputation
         :param imputation_suffix: suffix for imputation columns
         :param score_suffix: suffix for imputation score columns
+        :param inplace: whether to add columns to passed DataFrame.
         :return: original dataframe with imputations and their likelihoods in additional columns
         """
+
+        if not inplace:
+            data_frame = data_frame.copy()
+
         numerical_outputs = list(
             itertools.chain(
                 *[c.input_columns for c in self.label_encoders if isinstance(c, NumericalEncoder)]))

--- a/datawig/simple_imputer.py
+++ b/datawig/simple_imputer.py
@@ -441,7 +441,8 @@ class SimpleImputer:
                 data_frame: pd.DataFrame,
                 precision_threshold: float = 0.0,
                 imputation_suffix: str = "_imputed",
-                score_suffix: str = "_imputed_proba"):
+                score_suffix: str = "_imputed_proba",
+                inplace: bool = False):
         """
         Imputes most likely value if it is above a certain precision threshold determined on the
             validation set
@@ -456,10 +457,11 @@ class SimpleImputer:
         :param precision_threshold: double between 0 and 1 indicating precision threshold
         :param imputation_suffix: suffix for imputation columns
         :param score_suffix: suffix for imputation score columns
+        :param inplace: whether to add columns to passed DataFrame
         :return: data_frame original dataframe with imputations and likelihood in additional column
         """
         imputations = self.imputer.predict(data_frame, precision_threshold, imputation_suffix,
-                                           score_suffix)
+                                           score_suffix, inplace=inplace)
 
         return imputations
 

--- a/test/test_explain.py
+++ b/test/test_explain.py
@@ -67,7 +67,7 @@ def test_explain_method_synthetic(test_dir):
     # Train
     tr, te = random_split(df.sample(90), [.8, .2])
     imputer.fit(train_df=tr, test_df=te, num_epochs=10, learning_rate = 1e-2)
-    imputer.predict(te)
+    imputer.predict(te, inplace=True)
 
     # Evaluate
     assert precision_score(te.out_cat, te.out_cat_imputed, average='weighted') > .99

--- a/test/test_imputer.py
+++ b/test/test_imputer.py
@@ -597,3 +597,25 @@ def test_mxnet_module_wrapper(data_frame):
     assert mod.data_names == [feature_col]
     # weights and biases
     assert len(mod._arg_params) == 2
+
+
+def test_inplace_prediction(test_dir, data_frame):
+    label_col = 'label'
+    df = data_frame(n_samples=100, label_col=label_col)
+
+    data_encoder_cols = [TfIdfEncoder('features')]
+    label_encoder_cols = [CategoricalEncoder(label_col)]
+    data_cols = [BowFeaturizer('features')]
+
+    output_path = os.path.join(test_dir, "tmp", "out")
+
+    imputer = Imputer(
+        data_featurizers=data_cols,
+        label_encoders=label_encoder_cols,
+        data_encoders=data_encoder_cols,
+        output_path=output_path
+    ).fit(train_df=df, num_epochs=1)
+
+    predicted = imputer.predict(df, inplace=True)
+
+    assert predicted is df

--- a/test/test_simple_imputer.py
+++ b/test/test_simple_imputer.py
@@ -92,7 +92,7 @@ def test_simple_imputer_real_data_default_args(test_dir, data_frame):
     del (df_no_label_column[label_col])
     df_test_cols_before = df_no_label_column.columns.tolist()
 
-    df_test_imputed = imputer.predict(df_no_label_column)
+    df_test_imputed = imputer.predict(df_no_label_column, inplace=True)
 
     assert all(
         [after == before for after, before in zip(df_no_label_column.columns, df_test_cols_before)])
@@ -118,7 +118,7 @@ def test_simple_imputer_real_data_default_args(test_dir, data_frame):
 
     retrained_simple_imputer = deserialized.fit(df_train, df_train)
 
-    df_train_imputed = retrained_simple_imputer.predict(df_train.copy())
+    df_train_imputed = retrained_simple_imputer.predict(df_train.copy(), inplace=True)
     f1 = f1_score(df_train[label_col], df_train_imputed[label_col + '_imputed'], average="weighted")
 
     assert f1 > .9
@@ -171,7 +171,7 @@ def test_numeric_or_text_imputer(test_dir, data_frame):
         learning_rate=1e-3,
     )
 
-    imputer_numeric_linear.predict(df_test)
+    imputer_numeric_linear.predict(df_test, inplace=True)
 
     assert mean_squared_error(df_test['*2'], df_test['*2_imputed']) < 1.0
 
@@ -184,7 +184,7 @@ def test_numeric_or_text_imputer(test_dir, data_frame):
         learning_rate=1e-3
     )
 
-    imputer_numeric.predict(df_test)
+    imputer_numeric.predict(df_test, inplace=True)
 
     assert mean_squared_error(df_test['**2'], df_test['**2_imputed']) < 1.0
 
@@ -196,7 +196,7 @@ def test_numeric_or_text_imputer(test_dir, data_frame):
         train_df=df_train
     )
 
-    imputer_string.predict(df_test)
+    imputer_string.predict(df_test, inplace=True)
 
     assert f1_score(df_test[label_col], df_test[label_col + '_imputed'], average="weighted") > .7
 
@@ -234,7 +234,7 @@ def test_imputer_hpo_numeric(test_dir):
         numeric_hidden_layers_candidates=[1, 2]
     )
 
-    imputer_numeric.predict(df_test)
+    imputer_numeric.predict(df_test, inplace=True)
 
     assert mean_squared_error(df_test['**2'], df_test['**2_imputed']) < 1.0
 
@@ -277,6 +277,6 @@ def test_imputer_hpo_text(test_dir, data_frame):
         hpo_max_train_samples=1000
     )
 
-    imputer_string.predict(df_test)
+    imputer_string.predict(df_test, inplace=True)
 
     assert f1_score(df_test[label_col], df_test[label_col + '_imputed'], average="weighted") > .7


### PR DESCRIPTION
By default, data frames are no longer modified in place when calling `.predict()`.
Behaviour can be modified with additional boolean parameter _in_place_ (equals _False_ by default).

Solves [issue 18](https://github.com/awslabs/datawig/issues/18)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
