### PR TITLE
Tammruka/improve explanations

### DIFF
--- a/datawig/imputer.py
+++ b/datawig/imputer.py
@@ -368,7 +368,11 @@ class Imputer:
         return token_weights
 
 
-    def explain_instance(self, instance: pd.core.series.Series, k: int = 10, label_column: str = None) -> dict:
+    def explain_instance(self,
+                         instance: pd.core.series.Series,
+                         k: int = 10,
+                         label_column: str = None,
+                         label: str = None) -> dict:
         """
         Return dictionary with entries for each explainable input column of the given instance.
         Each entry shows the most likely class label for the input and the features with the highest correlation
@@ -377,38 +381,53 @@ class Imputer:
         :param instance: row of data frame (or dictionary)
         :param k: number of explanations (ngrams) for text inputs
         :param label_column: name of label column to be explained (optional)
+        :param label: explain why instance is classified as label, otherwise explain top-label per input
         """
 
         label_encoder = self.__get_label_encoder(label_column)
+
+        # determine label wrt which to compute correlations, default is global top prediction
+        if label is None:
+            df_temp = pd.DataFrame([list(instance.values)], columns=list(instance.index))
+            relevant_columns = np.unique([item for sublist in
+                                         [enc.input_columns for enc, vals in self.__class_patterns]
+                                         for item in sublist]
+            df_temp
+            label = self.predict(df_temp)[label_encoder.output_column + '_imputed'].values()[0]
+        else:
+            assert label in label_encoder.token_to_idx.keys()
 
         # encode instance columns
         feature_tuples = {}
         for encoder, pattern in self.__class_patterns:
 
-            token = instance[encoder.output_column]  # original input
-            feature_tuples[encoder.output_column] = {}
+            output_col = encoder.output_column
+            feature_tuples[output_col] = {}
 
-            if isinstance(encoder, TfIdfEncoder):
-                input_encoded = encoder.vectorizer.transform([token]).todense()  # encode
-                projection = input_encoded.dot(pattern)  # project input onto prototypes
-                top_label_idx = np.argmax(projection)
-                feature_weights = np.multiply(pattern[:, top_label_idx], input_encoded) # correlation of label/feature
-                ordered_feature_idx = np.argsort(np.multiply(pattern[:, top_label_idx], input_encoded))
-                ordered_feature_idx = ordered_feature_idx.tolist()[0][::-1]
+            for input_col in encoder.input_columns:
 
-                feature_tuples[encoder.output_column]['top_class'] = label_encoder.idx_to_token[top_label_idx]
-                feature_tuples[encoder.output_column]['token_weights'] =\
-                    [(encoder.idx_to_token[idx], feature_weights[0, idx]) for idx in ordered_feature_idx[:k]]
+                token = instance[input_col]
+                # token = instance[encoder.input_columns]  # original input
 
-            elif isinstance(encoder, CategoricalEncoder):
-                input_encoded = encoder.token_to_idx[token] - 1  # starts counting at 1
-                class_weights = pattern[input_encoded]  # correlation of input class with output classes
-                top_class_idx = np.argmax(class_weights)
-                top_class = label_encoder.idx_to_token[top_class_idx]
-                top_class_weight = pattern[input_encoded, top_class_idx]
+                if isinstance(encoder, TfIdfEncoder):
+                    input_encoded = encoder.vectorizer.transform([token]).todense()  # encode
+                    projection = input_encoded.dot(pattern)  # project input onto prototypes
+                    top_label_idx = label_encoder.token_to_idx[label]
+                    feature_weights = np.multiply(pattern[:, top_label_idx], input_encoded) # correlation of label/feature
+                    ordered_feature_idx = np.argsort(np.multiply(pattern[:, top_label_idx], input_encoded))
+                    ordered_feature_idx = ordered_feature_idx.tolist()[0][::-1]
 
-                feature_tuples[encoder.output_column]['top_class'] = top_class
-                feature_tuples[encoder.output_column]['token_weights'] = [(token, top_class_weight)]
+                    feature_tuples[output_col][label_encoder.idx_to_token[top_label_idx]] = \
+                        [(encoder.idx_to_token[idx], feature_weights[0, idx]) for idx in ordered_feature_idx[:k]]
+
+                elif isinstance(encoder, CategoricalEncoder):
+                    input_encoded = encoder.token_to_idx[token] - 1  # starts counting at 1
+                    class_weights = pattern[input_encoded]  # correlation of input class with output classes
+                    top_class_idx = np.argmax(class_weights)
+                    top_class = label_encoder.idx_to_token[top_class_idx]
+                    top_class_weight = pattern[input_encoded, top_class_idx]
+
+                    feature_tuples[output_col][top_class] = [(token, top_class_weight)]
 
         return feature_tuples
 
@@ -622,8 +641,7 @@ class Imputer:
         if not self.module.for_training:
             self.module.bind(data_shapes=mxnet_iter.provide_data,
                              label_shapes=mxnet_iter.provide_label)
-        # FIXME: truncation to [:mxnet_iter.start_padding_idx] because of having to set
-        # last_batch_handle to discard.
+        # FIXME: truncation to [:mxnet_iter.start_padding_idx] because of having to set last_batch_handle to discard.
         # truncating bottom rows for each output module while preserving all the columns
         mod_output = [o.asnumpy()[:mxnet_iter.start_padding_idx, :] for o in
                       self.module.predict(mxnet_iter)[1:]]

--- a/datawig/imputer.py
+++ b/datawig/imputer.py
@@ -300,7 +300,7 @@ class Imputer:
         for feature_matrix_scaled, encoder in zip(X_scaled, explainable_data_encoders):
             if isinstance(encoder, TfIdfEncoder):
                 # project features onto labels and sum across items
-                class_patterns.append((encoder, feature_matrix_scaled.dot(p_normalized)))
+                class_patterns.append((encoder, feature_matrix_scaled[:, :p_normalized.shape[0]].dot(p_normalized)))
             elif isinstance(encoder, CategoricalEncoder):
                 # compute mean class output for all input labels
                 class_patterns.append((encoder, np.array(

--- a/test/test_explain.py
+++ b/test/test_explain.py
@@ -101,5 +101,4 @@ def test_explain_method_synthetic(test_dir):
     imputer.save()
     imputer_from_disk = Imputer.load(imputer.output_path)
     assert np.all(['f' in token for token, weight in imputer_from_disk.explain('foo')['in_text']][:3])
-
-test_explain_method_synthetic('/tmp')
+    

--- a/test/test_explain.py
+++ b/test/test_explain.py
@@ -67,25 +67,33 @@ def test_explain_method_synthetic(test_dir):
     # Train
     tr, te = random_split(df.sample(90), [.8, .2])
     imputer.fit(train_df=tr, test_df=te, num_epochs=10, learning_rate = 1e-2)
-    imputer.predict(te, inplace=True)
+    predictions = imputer.predict(te)
 
     # Evaluate
-    assert precision_score(te.out_cat, te.out_cat_imputed, average='weighted') > .99
+    assert precision_score(predictions.out_cat, predictions.out_cat_imputed, average='weighted') > .99
 
     # assert item explanation, iterate over some inputs
     for i in np.random.choice(N, 10):
+
+        # any instance label needs to be explained by at least on appropriate input column
         text_explain = imputer.explain_instance(df.iloc[i])['in_text']
         cat_explain = imputer.explain_instance(df.iloc[i])['in_cat']
 
-        if text_explain['top_class'] == 'bar':
-            assert text_explain['token_weights'][0][0] == 'd'
-        elif text_explain['top_class'] == 'foo':
-            assert text_explain['token_weights'][0][0] == 'f'
+        instance_explained_by_appropriate_feature = False
 
-        if cat_explain['top_class'] == 'bar':
-            assert cat_explain['token_weights'][0][0] == 'dummy'
-        elif cat_explain['top_class'] == 'foo':
-            assert cat_explain['token_weights'][0][0] == 'foo'
+        top_label_text = list(text_explain.keys())[0]
+        if top_label_text == 'bar' and text_explain[top_label_text][0][0] == 'd':
+            instance_explained_by_appropriate_feature = True
+        elif top_label_text == 'foo' and text_explain[top_label_text][0][0] == 'f':
+            instance_explained_by_appropriate_feature = True
+
+        top_label_cat = list(cat_explain.keys())[0]
+        if top_label_cat == 'bar' and cat_explain[top_label_cat][0][0] == 'dummy':
+            instance_explained_by_appropriate_feature = True
+        elif top_label_cat == 'foo' and cat_explain[top_label_cat][0][0] == 'foo':
+            instance_explained_by_appropriate_feature = True
+
+        assert instance_explained_by_appropriate_feature == True
 
     # assert class explanations
     assert np.all(['f' in token for token, weight in imputer.explain('foo')['in_text']][:3])

--- a/test/test_explain.py
+++ b/test/test_explain.py
@@ -84,14 +84,6 @@ def test_explain_method_synthetic(test_dir):
             assert (explanation['in_text'][0][0] == 'd' and explanation['in_cat'][0][0] == 'dummy')
         elif top_label == 'foo':
             assert (explanation['in_text'][0][0] == 'f' or explanation['in_cat'][0][0] == 'foo')
-        #
-        #
-        # if top_label == 'bar' and explanation['in_cat'][0][0] == 'dummy':
-        #     instance_explained_by_appropriate_feature = True
-        # elif top_label == 'foo' and explanation['in_cat'][0][0] == 'foo':
-        #     instance_explained_by_appropriate_feature = True
-        #
-        # assert instance_explained_by_appropriate_feature == True
 
     # assert class explanations
     assert np.all(['f' in token for token, weight in imputer.explain('foo')['in_text']][:3])


### PR DESCRIPTION
Unifies return dictionary of explain and explain_instance methods, which now both have the format
{
''explained_label": "label_name"
"input_column_name_1": [(token1_1, weight1_1), (token1_2, weight1_2), ...],
"input_column_name_2": [(token2_1, weight2_1), (token2_2, weight2_2), ...],
...
}

Now also supports encoders with multiple output columns for the same input, e.g. for combining different featurisation methods on the same input column.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
