### PR TITLE
Systematic hyperparameter optimisation: Refactor

### DIFF
--- a/datawig/mxnet_input_symbols.py
+++ b/datawig/mxnet_input_symbols.py
@@ -52,6 +52,7 @@ class Featurizer(object):
         """
         return self.symbol
 
+
 class NumericalFeaturizer(Featurizer):
     """
 
@@ -102,7 +103,7 @@ class LSTMFeaturizer(Featurizer):
     def __init__(self,
                  field_name: str,
                  seq_len: int = 500,
-                 vocab_size: int = 40,
+                 max_tokens: int = 40,
                  embed_dim: int = 50,
                  num_hidden: int = 50,
                  num_layers: int = 2,
@@ -110,7 +111,7 @@ class LSTMFeaturizer(Featurizer):
                  use_gpu: bool = False if mx.cpu() in get_context() else True) -> None:
         super(LSTMFeaturizer, self).__init__(field_name, latent_dim)
 
-        self.vocab_size = int(vocab_size)
+        self.vocab_size = int(max_tokens)
         self.embed_dim = int(embed_dim)
         self.seq_len = int(seq_len)
         self.num_hidden = int(num_hidden)
@@ -151,11 +152,11 @@ class EmbeddingFeaturizer(Featurizer):
 
     def __init__(self,
                  field_name: str,
-                 vocab_size: int = 100,
+                 max_tokens: int = 100,
                  embed_dim: int = 10) -> None:
         super(EmbeddingFeaturizer, self).__init__(field_name, embed_dim)
 
-        self.vocab_size = int(vocab_size)
+        self.vocab_size = int(max_tokens)
         self.embed_dim = int(embed_dim)
 
         with mx.name.Prefix(field_name + "_"):
@@ -179,8 +180,8 @@ class BowFeaturizer(Featurizer):
 
     def __init__(self,
                  field_name: str,
-                 vocab_size: int = 2 ** 15) -> None:
-        super(BowFeaturizer, self).__init__(field_name, vocab_size)
+                 max_tokens: int = 2 ** 15) -> None:
+        super(BowFeaturizer, self).__init__(field_name, max_tokens)
 
         with mx.name.Prefix(field_name + "_"):
             self.symbol = mx.sym.Variable("{}".format(field_name), stype='csr')

--- a/datawig/utils.py
+++ b/datawig/utils.py
@@ -26,6 +26,7 @@ import random
 import sys
 import time
 from typing import Any, List, Tuple
+import collections
 
 import mxnet as mx
 import numpy as np
@@ -43,6 +44,20 @@ consoleHandler.setFormatter(log_formatter)
 logger.addHandler(consoleHandler)
 
 logger.setLevel("INFO")
+
+
+def flatten_dict(d, parent_key='', sep=':'):
+    """
+    Flatten a nested dictionary and create new keys by concatenation
+    """
+    items = []
+    for k, v in d.items():
+        new_key = parent_key + sep + k if parent_key else k
+        if isinstance(v, collections.MutableMapping):
+            items.extend(flatten_dict(v, new_key, sep=sep).items())
+        else:
+            items.append((new_key, v))
+    return dict(items)
 
 
 class ColumnOverwriteException(Exception):

--- a/test/test_calibration.py
+++ b/test/test_calibration.py
@@ -98,11 +98,11 @@ def test_automatic_calibration(data_frame):
 
     # generate some random data
     random_data = data_frame(feature_col=feature_col,
-                                             label_col=label_col,
-                                             vocab_size=vocab_size,
-                                             num_labels=num_labels,
-                                             num_words=seq_len,
-                                             n_samples=n_samples)
+                             label_col=label_col,
+                             vocab_size=vocab_size,
+                             num_labels=num_labels,
+                             num_words=seq_len,
+                             n_samples=n_samples)
 
     # we use a the label prefixes as a dummy categorical input variable
     random_data[categorical_col] = random_data[label_col].apply(lambda x: x[:2])
@@ -119,7 +119,7 @@ def test_automatic_calibration(data_frame):
     data_cols = [
         BowFeaturizer(
             feature_col + "_bow",
-            vocab_size=vocab_size),
+            max_tokens=vocab_size),
         LSTMFeaturizer(
             field_name=feature_col + "_lstm",
             seq_len=seq_len,
@@ -127,11 +127,11 @@ def test_automatic_calibration(data_frame):
             num_hidden=30,
             embed_dim=embed_dim,
             num_layers=2,
-            vocab_size=num_labels),
+            max_tokens=num_labels),
         EmbeddingFeaturizer(
             field_name=categorical_col,
             embed_dim=embed_dim,
-            vocab_size=num_labels)
+            max_tokens=num_labels)
     ]
 
     num_epochs = 20

--- a/test/test_imputer.py
+++ b/test/test_imputer.py
@@ -49,7 +49,7 @@ def test_drop_missing(test_dir):
 
     data_encoder_cols = [BowEncoder('data', max_tokens=max_tokens)]
     label_encoder_cols = [CategoricalEncoder('label', max_tokens=1)]
-    data_cols = [BowFeaturizer('data', vocab_size=max_tokens)]
+    data_cols = [BowFeaturizer('data', max_tokens=max_tokens)]
 
     output_path = os.path.join(test_dir, "tmp", "real_data_experiment")
 
@@ -143,7 +143,7 @@ def test_imputer_duplicate_encoder_output_columns(test_dir, data_frame):
     n_samples = 1000
     num_labels = 10
     seq_len = 100
-    vocab_size = int(2 ** 10)
+    max_tokens = int(2 ** 10)
 
     latent_dim = 30
     embed_dim = 30
@@ -151,7 +151,7 @@ def test_imputer_duplicate_encoder_output_columns(test_dir, data_frame):
     # generate some random data
     random_data = data_frame(feature_col=feature_col,
                                              label_col=label_col,
-                                             vocab_size=vocab_size,
+                                             vocab_size=max_tokens,
                                              num_labels=num_labels,
                                              num_words=seq_len,
                                              n_samples=n_samples)
@@ -162,8 +162,8 @@ def test_imputer_duplicate_encoder_output_columns(test_dir, data_frame):
     df_train, df_test, df_val = random_split(random_data, [.8, .1, .1])
 
     data_encoder_cols = [
-        BowEncoder(feature_col, feature_col, max_tokens=vocab_size),
-        SequentialEncoder(feature_col, feature_col, max_tokens=vocab_size, seq_len=seq_len),
+        BowEncoder(feature_col, feature_col, max_tokens=max_tokens),
+        SequentialEncoder(feature_col, feature_col, max_tokens=max_tokens, seq_len=seq_len),
         CategoricalEncoder(categorical_col, max_tokens=num_labels)
     ]
     label_encoder_cols = [CategoricalEncoder(label_col, max_tokens=num_labels)]
@@ -171,7 +171,7 @@ def test_imputer_duplicate_encoder_output_columns(test_dir, data_frame):
     data_cols = [
         BowFeaturizer(
             feature_col,
-            vocab_size=vocab_size),
+            max_tokens=max_tokens),
         LSTMFeaturizer(
             field_name=feature_col,
             seq_len=seq_len,
@@ -179,11 +179,11 @@ def test_imputer_duplicate_encoder_output_columns(test_dir, data_frame):
             num_hidden=30,
             embed_dim=embed_dim,
             num_layers=2,
-            vocab_size=num_labels),
+            max_tokens=num_labels),
         EmbeddingFeaturizer(
             field_name=categorical_col,
             embed_dim=embed_dim,
-            vocab_size=num_labels)
+            max_tokens=num_labels)
     ]
 
     output_path = os.path.join(test_dir, "tmp",
@@ -222,7 +222,7 @@ def test_imputer_real_data_all_featurizers(test_dir, data_frame):
     n_samples = 5000
     num_labels = 3
     seq_len = 20
-    vocab_size = int(2 ** 10)
+    max_tokens = int(2 ** 10)
 
     latent_dim = 30
     embed_dim = 30
@@ -230,7 +230,7 @@ def test_imputer_real_data_all_featurizers(test_dir, data_frame):
     # generate some random data
     random_data = data_frame(feature_col=feature_col,
                                              label_col=label_col,
-                                             vocab_size=vocab_size,
+                                             vocab_size=max_tokens,
                                              num_labels=num_labels,
                                              num_words=seq_len,
                                              n_samples=n_samples)
@@ -241,8 +241,8 @@ def test_imputer_real_data_all_featurizers(test_dir, data_frame):
     df_train, df_test, df_val = random_split(random_data, [.8, .1, .1])
 
     data_encoder_cols = [
-        BowEncoder(feature_col, feature_col + "_bow", max_tokens=vocab_size),
-        SequentialEncoder(feature_col, feature_col + "_lstm", max_tokens=vocab_size, seq_len=seq_len),
+        BowEncoder(feature_col, feature_col + "_bow", max_tokens=max_tokens),
+        SequentialEncoder(feature_col, feature_col + "_lstm", max_tokens=max_tokens, seq_len=seq_len),
         CategoricalEncoder(categorical_col, max_tokens=num_labels)
     ]
     label_encoder_cols = [CategoricalEncoder(label_col, max_tokens=num_labels)]
@@ -250,7 +250,7 @@ def test_imputer_real_data_all_featurizers(test_dir, data_frame):
     data_cols = [
         BowFeaturizer(
             feature_col + "_bow",
-            vocab_size=vocab_size),
+            max_tokens=max_tokens),
         LSTMFeaturizer(
             field_name=feature_col + "_lstm",
             seq_len=seq_len,
@@ -258,11 +258,11 @@ def test_imputer_real_data_all_featurizers(test_dir, data_frame):
             num_hidden=30,
             embed_dim=embed_dim,
             num_layers=2,
-            vocab_size=num_labels),
+            max_tokens=num_labels),
         EmbeddingFeaturizer(
             field_name=categorical_col,
             embed_dim=embed_dim,
-            vocab_size=num_labels)
+            max_tokens=num_labels)
     ]
 
     output_path = os.path.join(test_dir, "tmp", "imputer_experiment_synthetic_data")
@@ -378,12 +378,12 @@ def test_imputer_without_test_set_random_split(test_dir, data_frame):
     n_samples = 5000
     num_labels = 3
     seq_len = 20
-    vocab_size = int(2 ** 10)
+    max_tokens = int(2 ** 10)
 
     # generate some random data
     df_train = data_frame(feature_col=feature_col,
                                              label_col=label_col,
-                                             vocab_size=vocab_size,
+                                             vocab_size=max_tokens,
                                              num_labels=num_labels,
                                              num_words=seq_len,
                                              n_samples=n_samples)
@@ -394,12 +394,12 @@ def test_imputer_without_test_set_random_split(test_dir, data_frame):
     learning_rate = 1e-3
 
     data_encoder_cols = [
-        BowEncoder(feature_col, max_tokens=vocab_size)
+        BowEncoder(feature_col, max_tokens=max_tokens)
     ]
     label_encoder_cols = [CategoricalEncoder(label_col, max_tokens=num_labels)]
 
     data_cols = [
-        BowFeaturizer(feature_col, vocab_size=vocab_size)
+        BowFeaturizer(feature_col, max_tokens=max_tokens)
     ]
 
     output_path = os.path.join(test_dir, "tmp", "real_data_experiment")
@@ -588,7 +588,7 @@ def test_mxnet_module_wrapper(data_frame):
     df = data_frame(n_samples=100, feature_col=feature_col, label_col=label_col)
     label_encoders = [CategoricalEncoder(label_col)]
     data_encoders = [BowEncoder(feature_col)]
-    data_featurizers = [BowFeaturizer(feature_col, vocab_size=100)]
+    data_featurizers = [BowFeaturizer(feature_col, max_tokens=100)]
     iter_train = ImputerIterDf(df, data_encoders, label_encoders)
 
     mod = _MXNetModule(mx.current_context(), label_encoders, data_featurizers, final_fc_hidden_units=[])(iter_train)

--- a/test/test_simple_imputer.py
+++ b/test/test_simple_imputer.py
@@ -25,6 +25,7 @@ import pandas as pd
 import pytest
 from sklearn.metrics import f1_score, mean_squared_error
 
+from datawig.hpo import HPO
 from datawig.column_encoders import BowEncoder
 from datawig.mxnet_input_symbols import BowFeaturizer
 from datawig.simple_imputer import SimpleImputer
@@ -57,11 +58,11 @@ def test_simple_imputer_real_data_default_args(test_dir, data_frame):
 
     # generate some random data
     random_data = data_frame(feature_col=feature_col,
-                                             label_col=label_col,
-                                             vocab_size=vocab_size,
-                                             num_labels=num_labels,
-                                             num_words=seq_len,
-                                             n_samples=n_samples)
+                             label_col=label_col,
+                             vocab_size=vocab_size,
+                             num_labels=num_labels,
+                             num_words=seq_len,
+                             n_samples=n_samples)
 
     df_train, df_test, df_val = random_split(random_data, [.8, .1, .1])
 
@@ -216,27 +217,32 @@ def test_imputer_hpo_numeric(test_dir):
     })
 
     df_train, df_test = random_split(df, [.8, .2])
-    output_path = os.path.join(test_dir, "tmp", "real_data_experiment_numeric_hpo")
+    output_path = os.path.join(test_dir, "tmp", "experiment_numeric_hpo")
 
     imputer_numeric = SimpleImputer(
         input_columns=['x'],
         output_column="**2",
-        output_path=output_path
-    )
-    imputer_numeric.fit_hpo(
-        train_df=df_train,
-        learning_rate=1e-3,
-        num_epochs=100,
-        patience=10,
-        num_hash_bucket_candidates=[2 ** 10],
-        tokens_candidates=['words'],
-        numeric_latent_dim_candidates=[10, 50, 100],
-        numeric_hidden_layers_candidates=[1, 2]
-    )
+        output_path=output_path)
 
-    imputer_numeric.predict(df_test, inplace=True)
+    feature_col = 'x'
 
-    assert mean_squared_error(df_test['**2'], df_test['**2_imputed']) < 1.0
+    hps = {}
+    hps[feature_col] = {}
+    hps[feature_col]['type'] = ['numeric']
+    hps[feature_col]['numeric_latent_dim'] = [30]
+    hps[feature_col]['numeric_hidden_layers'] = [1]
+
+    hps['global'] = {}
+    hps['global']['final_fc_hidden_units'] = [[]]
+    hps['global']['learning_rate'] = [1e-3, 1e-4]
+    hps['global']['weight_decay'] = [0]
+    hps['global']['num_epochs'] = [50]
+
+    hpo = HPO(imputer_numeric, hps)
+
+    results = hpo.tune(df)
+
+    assert results[results['mse'] == min(results['mse'])]['mse'].iloc[0] < 1.0
 
 
 def test_imputer_hpo_text(test_dir, data_frame):
@@ -254,29 +260,117 @@ def test_imputer_hpo_text(test_dir, data_frame):
 
     # generate some random data
     df = data_frame(feature_col=feature_col,
-                                    label_col=label_col,
-                                    num_labels=num_labels,
-                                    num_words=seq_len,
-                                    n_samples=n_samples)
+                    label_col=label_col,
+                    num_labels=num_labels,
+                    num_words=seq_len,
+                    n_samples=n_samples)
 
     df_train, df_test = random_split(df, [.8, .2])
-    output_path = os.path.join(test_dir, "tmp", "real_data_experiment_text_hpo")
+
+    output_path = os.path.join(test_dir, "tmp", "experiment_text_hpo")
 
     imputer_string = SimpleImputer(
         input_columns=[feature_col],
         output_column=label_col,
         output_path=output_path
     )
-    imputer_string.fit_hpo(
-        train_df=df_train,
-        num_epochs=100,
-        patience=3,
-        num_hash_bucket_candidates=[2 ** 10, 2 ** 15],
-        tokens_candidates=['words'],
-        numeric_latent_dim_candidates=[10],
-        hpo_max_train_samples=1000
+
+    hps = {}
+    hps[feature_col] = {}
+    hps[feature_col]['type'] = ['string']
+    hps[feature_col]['tokens'] = [['words'], ['chars']]
+
+    hps['global'] = {}
+    hps['global']['final_fc_hidden_units'] = [[]]
+    hps['global']['learning_rate'] = [1e-3]
+    hps['global']['weight_decay'] = [0]
+    hps['global']['num_epochs'] = [30]
+
+    hpo = HPO(imputer_string, hps)
+    out = hpo.tune(df_train)
+
+    assert max(out['f1_micro']) > .9
+
+
+def test_hpo_all_input_types(test_dir, data_frame):
+    """
+
+    Using sklearn advantages: parallelism, distributions of parameters, multiple cross-validation
+
+    """
+    label_col = "label"
+
+    n_samples = 1000
+    num_labels = 3
+    seq_len = 20
+
+    # generate some random data
+    df = data_frame(feature_col="string_feature",
+                    label_col=label_col,
+                    num_labels=num_labels,
+                    num_words=seq_len,
+                    n_samples=n_samples)
+
+    # add categorical feature
+    df['categorical_feature'] = ['foo' if r > .5 else 'bar' for r in np.random.rand(n_samples)]
+
+    # add numerical feature
+    df['numeric_feature'] = np.random.rand(n_samples)
+
+    df_train, df_test = random_split(df, [.8, .2])
+    output_path = os.path.join(test_dir, "tmp", "real_data_experiment_text_hpo")
+
+    imputer = SimpleImputer(
+        input_columns=['string_feature', 'categorical_feature', 'numeric_feature'],
+        output_column='label',
+        output_path=output_path
     )
 
-    imputer_string.predict(df_test, inplace=True)
+    # Define default hyperparameter choices for each column type (string, categorical, numeric)
+    hps = dict()
+    hps['global'] = {}
+    hps['global']['learning_rate'] = [1e-4]
+    hps['global']['weight_decay'] = [3e-4]
+    hps['global']['num_epochs'] = [5, 50]
+    hps['global']['patience'] = [5]
+    hps['global']['batch_size'] = [16]
+    hps['global']['final_fc_hidden_units'] = [[]]
 
-    assert f1_score(df_test[label_col], df_test[label_col + '_imputed'], average="weighted") > .7
+    hps['string_feature'] = {}
+    hps['string_feature']['max_tokens'] = [2 ** 8]
+    hps['string_feature']['tokens'] = [['words', 'chars']]
+
+    hps['categorical_feature'] = {}
+    hps['categorical_feature']['type'] = ['categorical']
+    hps['categorical_feature']['max_tokens'] = [2 ** 8]
+    hps['categorical_feature']['embed_dim'] = [10]
+
+    hps['numeric_feature'] = {}
+    hps['numeric_feature']['normalize'] = [True]
+    hps['numeric_feature']['numeric_latent_dim'] = [10]
+    hps['numeric_feature']['numeric_hidden_layers'] = [1]
+
+    # user defined score function for hyperparameters
+    def calibration_check(**kwargs):
+        """
+        expect kwargs: true, predicted, confidence
+        here we compute a calibration sanity check
+        """
+        true = kwargs['true']
+        confidence = kwargs['confidence']
+        predicted = kwargs['predicted']
+        return (np.mean(true[confidence > .9] == predicted[confidence > .9]),
+                np.mean(true[confidence > .5] == predicted[confidence > .5]))
+
+    def coverage_check(**kwargs):
+        return np.mean(kwargs['confidence'] > .9)
+
+    uds = [(calibration_check, 'calibration check'),
+           (coverage_check, 'coverage at 90')]
+
+    hpo = HPO(imputer, hps)
+    results = hpo.tune(df_train, user_defined_scores=uds)
+
+    assert results[results['global:num_epochs'] == 50]['f1_micro'].iloc[0] > \
+           results[results['global:num_epochs'] == 5]['f1_micro'].iloc[0]
+


### PR DESCRIPTION
*Description of changes:*
Refactoring of this pull request: https://github.com/awslabs/datawig/pull/62
Thanks for the initial feedback. I've now moved HPO into it's own module.

I close the old pull request because big changes will be either to track here.
The inner workings stay mostly unchanged. I copy below the comments on the current limitations of this implementation:

_Let me be specific on what this was set out to do. I start with illustrating why this is difficult.
We want to be able to optimise all configurations of hyperparameters. This includes parameters with conditional dependencies. E.g. one hyperparameter for a particular column could be the column type: (categorical, string). If the column type is string, a next hyperparameter (that applies only conditionally on the previous one) is the embedding type (Tfidf, Hashing, LSTM). Each of these can again have a different set of conditional hyperparameters, and so on. There would be yet another parameter on top, that is the option to have multiple embeddings for the same column._

_It's natural to have a multi-level nested data-structure to store the different parameter values or distributions to draw from. This is done in the proposed implementation, but to keep things simple there are some limitations listed in the following._

_Only one string column embedding strategy is supported. This is hard coded (hashing vectoriser at the moment. Maybe swap for tfidf)
If the same column is embedded multiple times, these embeddings share all hyperparameters except for the token type (chars, words).
All input columns have a separate column encoder. There is no option to combine different columns into one (other than through pre-processing, which is easy enough)
There is no mechanism to automatically distinguish text from categorical columns. For categorical encodings, the user needs to supply the column type as parameter.
The same column can not be encoded as multiple types. E.g. string and categorical.
No support for drawing from distributions. Values need to be supplied as list.
I'd be interested in whether you think this is a reasonable compromise._


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
