### PR TITLE
Minor fix in _is_categorical

### DIFF
--- a/datawig/simple_imputer.py
+++ b/datawig/simple_imputer.py
@@ -148,7 +148,7 @@ class SimpleImputer:
 
         """
 
-        return col.sample(n=n_samples, replace=len(col) < 100).value_counts(
+        return col.sample(n=n_samples, replace=len(col) < n_samples).value_counts(
             normalize=True).min() >= min_value_histogram
 
     def fit_hpo(self,


### PR DESCRIPTION
One input argument, switching from sampling without replacement to sampling with replacement if not enough samples are available in a column, in SimpleImputer._is_categorical was not used. This commit fixes this.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
