### PR TITLE
Improve logging

### DIFF
--- a/datawig/imputer.py
+++ b/datawig/imputer.py
@@ -151,7 +151,7 @@ class Imputer:
         if not os.path.exists(self.output_path):
             os.makedirs(self.output_path)
 
-        self.__attach_log_filehandler(filename=os.path.join(self.output_path, 'logger.log'))
+        self.__attach_log_filehandler(filename=os.path.join(self.output_path, 'imputer.log'))
 
         self.module_path = os.path.join(self.output_path, "model")
 

--- a/datawig/imputer.py
+++ b/datawig/imputer.py
@@ -475,8 +475,9 @@ class Imputer:
                     optimizer='adam',
                     optimizer_params=(('learning_rate', learning_rate), ('wd', weight_decay)),
                     batch_end_callback=[mx.callback.Speedometer(iter_train.batch_size,
-                                                                int(iter_train.df_iterator.data[0][1].shape[
-                                                                        0] / iter_train.batch_size / 2),
+                                                                int(np.ceil(
+                                                                    iter_train.df_iterator.data[0][1].shape[0] /
+                                                                    iter_train.batch_size / 2)),
                                                                 auto_reset=True)],
                     eval_end_callback=[test_cb, train_cb],
                     epoch_end_callback=checkpoint

--- a/datawig/imputer.py
+++ b/datawig/imputer.py
@@ -474,10 +474,11 @@ class Imputer:
                     initializer=mx.init.Xavier(factor_type="in", magnitude=2.34),
                     optimizer='adam',
                     optimizer_params=(('learning_rate', learning_rate), ('wd', weight_decay)),
-                    batch_end_callback=[train_cb,
-                                        mx.callback.Speedometer(iter_train.batch_size, 20,
+                    batch_end_callback=[mx.callback.Speedometer(iter_train.batch_size,
+                                                                int(iter_train.df_iterator.data[0][1].shape[
+                                                                        0] / iter_train.batch_size / 2),
                                                                 auto_reset=True)],
-                    eval_end_callback=test_cb,
+                    eval_end_callback=[test_cb, train_cb],
                     epoch_end_callback=checkpoint
                 )
             except StopIteration:

--- a/datawig/imputer.py
+++ b/datawig/imputer.py
@@ -41,7 +41,8 @@ from .iterators import ImputerIterDf
 from .mxnet_input_symbols import Featurizer
 from .utils import (AccuracyMetric, ColumnOverwriteException,
                     LogMetricCallBack, MeanSymbol, get_context, logger,
-                    merge_dicts, random_split, timing)
+                    merge_dicts, random_split, timing, log_formatter)
+from logging import FileHandler
 
 
 class Imputer:
@@ -67,6 +68,7 @@ class Imputer:
                  data_featurizers: List[Featurizer],
                  label_encoders: List[ColumnEncoder],
                  output_path="") -> None:
+
 
         self.ctx = None
         self.module = None
@@ -127,6 +129,7 @@ class Imputer:
                         ", ".join(encoder_outputs), featurizer_type))
             # TODO: check whether encoder type matches requirements of featurizer
 
+
         # collect names of data and label columns
         input_col_names = [c.field_name for c in self.data_featurizers]
         label_col_names = list(itertools.chain(*[c.input_columns for c in self.label_encoders]))
@@ -148,9 +151,27 @@ class Imputer:
         if not os.path.exists(self.output_path):
             os.makedirs(self.output_path)
 
+        self.__attach_log_filehandler(filename=os.path.join(self.output_path, 'logger.log'))
+
         self.module_path = os.path.join(self.output_path, "model")
 
         self.metrics_path = os.path.join(self.output_path, "fit-test-metrics.json")
+
+    def __attach_log_filehandler(self, filename: str, level: str = "INFO") -> None:
+        """
+        Modifies global logger object and attaches filehandler
+
+        :param filename: path to logfile
+        :param level: logging level
+
+        """
+
+        logger.setLevel(level)
+
+        fileHandler = FileHandler(filename, mode='a')
+        fileHandler.setLevel(level)
+        fileHandler.setFormatter(log_formatter)
+        logger.addHandler(fileHandler)
 
     def __check_data(self, data_frame: pd.DataFrame) -> None:
         """

--- a/datawig/iterators.py
+++ b/datawig/iterators.py
@@ -30,7 +30,7 @@ from .utils import logger
 class ImputerIter(mx.io.DataIter):
     """
 
-    Constructs an MxNet Iterator for an datawig.imputation.Imputer given a table in csv format
+    Constructs an MxNet Iterator for a datawig.imputation.Imputer given a table in csv format
 
     :param data_columns: list of featurizers, see datawig.column_featurizer
     :param label_columns: list of featurizers
@@ -184,7 +184,7 @@ class ImputerIter(mx.io.DataIter):
 class ImputerIterDf(ImputerIter):
     """
 
-    Constructs an MxNet Iterator for an datawig.imputation.Imputer given a pandas dataframe
+    Constructs an MxNet Iterator for a datawig.imputation.Imputer given a pandas dataframe
 
     :param data_frame: pandas dataframe
     :param data_columns: list of featurizers, see datawig.column_featurizer

--- a/datawig/utils.py
+++ b/datawig/utils.py
@@ -35,26 +35,13 @@ mx.random.seed(1)
 random.seed(1)
 np.random.seed(42)
 
+# set global logger variables
 log_formatter = logging.Formatter("%(asctime)s [%(levelname)s]  %(message)s")
 logger = logging.getLogger()
-
 consoleHandler = logging.StreamHandler()
 consoleHandler.setFormatter(log_formatter)
 logger.addHandler(consoleHandler)
-
 logger.setLevel("INFO")
-
-
-def logger_settings(level: str = "INFO",
-                    file: str = None) -> None:
-
-    logger.setLevel(level)
-
-    log_formatter = logging.Formatter("%(asctime)s [%(levelname)s]  %(message)s")
-    if file is not None:
-        fileHandler = logging.FileHandler(file)
-        fileHandler.setFormatter(log_formatter)
-        logger.addHandler(fileHandler)
 
 
 def flatten_dict(d: Dict,

--- a/datawig/utils.py
+++ b/datawig/utils.py
@@ -45,6 +45,18 @@ logger.addHandler(consoleHandler)
 logger.setLevel("INFO")
 
 
+def logger_settings(level: str = "INFO",
+                    file: str = None) -> None:
+
+    logger.setLevel(level)
+
+    log_formatter = logging.Formatter("%(asctime)s [%(levelname)s]  %(message)s")
+    if file is not None:
+        fileHandler = logging.FileHandler(file)
+        fileHandler.setFormatter(log_formatter)
+        logger.addHandler(fileHandler)
+
+
 def flatten_dict(d: Dict,
                  parent_key: str ='',
                  sep: str =':') -> Dict:

--- a/test/test_simple_imputer.py
+++ b/test/test_simple_imputer.py
@@ -28,7 +28,7 @@ from sklearn.metrics import f1_score, mean_squared_error
 from datawig.column_encoders import BowEncoder
 from datawig.mxnet_input_symbols import BowFeaturizer
 from datawig.simple_imputer import SimpleImputer
-from datawig.utils import logger, rand_string, random_split, generate_df_numeric, generate_df_string, logger_settings
+from datawig.utils import logger, rand_string, random_split, generate_df_numeric, generate_df_string
 
 warnings.filterwarnings("ignore")
 
@@ -71,10 +71,6 @@ def test_simple_imputer_real_data_default_args(test_dir, data_frame):
 
     input_columns = [feature_col]
 
-    if not os.path.exists(output_path):
-        os.makedirs(output_path)
-    logger_settings(file=output_path + '/test_logging.log')
-
     imputer = SimpleImputer(
         input_columns=input_columns,
         output_column=label_col,
@@ -83,11 +79,16 @@ def test_simple_imputer_real_data_default_args(test_dir, data_frame):
         train_df=df_train
     )
 
+    logfile = os.path.join(imputer.output_path, 'logger.log')
+    assert os.path.exists(logfile)
+    assert os.path.getsize(logfile) > 0
+
     assert imputer.output_path == output_path
     assert imputer.imputer.data_featurizers[0].__class__ == BowFeaturizer
     assert imputer.imputer.data_encoders[0].__class__ == BowEncoder
     assert set(imputer.imputer.data_encoders[0].input_columns) == set(input_columns)
     assert set(imputer.imputer.label_encoders[0].input_columns) == set([label_col])
+
 
     assert all([after == before for after, before in zip(df_train.columns, df_train_cols_before)])
 

--- a/test/test_simple_imputer.py
+++ b/test/test_simple_imputer.py
@@ -79,7 +79,7 @@ def test_simple_imputer_real_data_default_args(test_dir, data_frame):
         train_df=df_train
     )
 
-    logfile = os.path.join(imputer.output_path, 'logger.log')
+    logfile = os.path.join(imputer.output_path, 'imputer.log')
     assert os.path.exists(logfile)
     assert os.path.getsize(logfile) > 0
 
@@ -345,8 +345,8 @@ def test_hpo_all_input_types(test_dir, data_frame):
     hps['string_feature']['max_tokens'] = [2 ** 15]
     hps['string_feature']['tokens'] = [['words', 'chars']]
     hps['string_feature']['ngram_range'] = {}
-    hps['string_feature']['ngram_range']['words'] = [(1, 4)]
-    hps['string_feature']['ngram_range']['chars'] = [(2, 4)]
+    hps['string_feature']['ngram_range']['words'] = [(1, 4), (2, 5)]
+    hps['string_feature']['ngram_range']['chars'] = [(2, 4), (3, 5)]
 
     hps['categorical_feature'] = {}
     hps['categorical_feature']['type'] = ['categorical']

--- a/test/test_simple_imputer.py
+++ b/test/test_simple_imputer.py
@@ -71,7 +71,9 @@ def test_simple_imputer_real_data_default_args(test_dir, data_frame):
 
     input_columns = [feature_col]
 
-    logger_settings(file='/Users/tammruka/Downloads/mylogs.log')
+    if not os.path.exists(output_path):
+        os.makedirs(output_path)
+    logger_settings(file=output_path + '/test_logging.log')
 
     imputer = SimpleImputer(
         input_columns=input_columns,

--- a/test/test_simple_imputer.py
+++ b/test/test_simple_imputer.py
@@ -28,7 +28,7 @@ from sklearn.metrics import f1_score, mean_squared_error
 from datawig.column_encoders import BowEncoder
 from datawig.mxnet_input_symbols import BowFeaturizer
 from datawig.simple_imputer import SimpleImputer
-from datawig.utils import logger, rand_string, random_split, generate_df_numeric, generate_df_string
+from datawig.utils import logger, rand_string, random_split, generate_df_numeric, generate_df_string, logger_settings
 
 warnings.filterwarnings("ignore")
 
@@ -70,6 +70,8 @@ def test_simple_imputer_real_data_default_args(test_dir, data_frame):
     df_train_cols_before = df_train.columns.tolist()
 
     input_columns = [feature_col]
+
+    logger_settings(file='/Users/tammruka/Downloads/mylogs.log')
 
     imputer = SimpleImputer(
         input_columns=input_columns,


### PR DESCRIPTION
This PR suggest to simple changes:
1) Allow the user to specify logging levels and an optional output path for log files in one line via `utils.logger_settings()`
2) Make the default output less versatile. In particular, we print metrics on the INFO level now once every epoch, instead of every 20 batches. The previous behaviour led to huge logs if the datasets had many (10k+) rows.
3) Compute training entropy after every epoch, not after every batch.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
