### PR TITLE
Hpo tweaks

### DIFF
--- a/datawig/_hpo.py
+++ b/datawig/_hpo.py
@@ -408,6 +408,10 @@ class _HPO:
         elapsed_time = 0
 
         for hp_idx, (_, hp) in enumerate(hps_flat.iterrows()):
+            if np.any([np.all(row == hp) for idx, row in self.results.iterrows()]):
+                logger.info('Configuration has already been learned. Move to next one.')
+                continue
+
             if elapsed_time > max_running_hours:
                 logger.info('Finishing hpo because max running time was reached.')
                 break

--- a/datawig/_hpo.py
+++ b/datawig/_hpo.py
@@ -408,9 +408,10 @@ class _HPO:
         elapsed_time = 0
 
         for hp_idx, (_, hp) in enumerate(hps_flat.iterrows()):
-            if np.any([np.all(row == hp) for idx, row in self.results.iterrows()]):
-                logger.info('Configuration has already been learned. Move to next one.')
-                continue
+            if set(self.results.columns) == set(hp.index):  # are column identical?
+                if np.any([np.all(row == hp) for idx, row in self.results.iterrows()]):  # are entries ident?
+                    logger.info('Configuration has already been learned. Move to next one.')
+                    continue
 
             if elapsed_time > max_running_hours:
                 logger.info('Finishing hpo because max running time was reached.')

--- a/datawig/_hpo.py
+++ b/datawig/_hpo.py
@@ -71,6 +71,7 @@ class _HPO:
         default_hps['global']['batch_size'] = [16]
         default_hps['global']['final_fc_hidden_units'] = [[], [100]]
         default_hps['global']['concat_columns'] = [False]
+        default_hps['global']['is_explainable'] = [False]
 
         default_hps['string'] = {}
         default_hps['string']['ngram_range'] = {}
@@ -210,6 +211,11 @@ class _HPO:
         data_encoders = []
         data_featurizers = []
 
+        if hp['global:is_explainable'] is True:
+            StringEncoder = TfIdfEncoder
+        else:
+            StringEncoder = BowEncoder
+
         if hp['global:concat_columns'] is False:
 
             # mark unused parameter
@@ -228,11 +234,11 @@ class _HPO:
                     # iterate over multiple embeddings (chars + strings for the same column)
                     for token in col_parms['tokens']:
                         # call kw. args. with: **{key: item for key, item in col_parms.items() if not key == 'type'})]
-                        data_encoders += [TfIdfEncoder(input_columns=[input_column],
-                                                       output_column=input_column + '_' + token,
-                                                       tokens=token,
-                                                       ngram_range=col_parms['ngram_range:'+token],
-                                                       max_tokens=col_parms['max_tokens'])]
+                        data_encoders += [StringEncoder(input_columns=[input_column],
+                                                        output_column=input_column + '_' + token,
+                                                        tokens=token,
+                                                        ngram_range=col_parms['ngram_range:'+token],
+                                                        max_tokens=col_parms['max_tokens'])]
                         data_featurizers += [BowFeaturizer(field_name=input_column + '_' + token,
                                                            max_tokens=col_parms['max_tokens'])]
 
@@ -262,11 +268,11 @@ class _HPO:
 
             col_parms = {':'.join(key.split(':')[1:]): val for key, val in hp.items() if 'concat' in key}
             for token in col_parms['tokens']:
-                data_encoders += [TfIdfEncoder(input_columns=simple_imputer.input_columns,
-                                               output_column='-'.join(simple_imputer.input_columns) + '_' + token,
-                                               tokens=token,
-                                               ngram_range=col_parms['ngram_range:' + token],
-                                               max_tokens=col_parms['max_tokens'])]
+                data_encoders += [StringEncoder(input_columns=simple_imputer.input_columns,
+                                                output_column='-'.join(simple_imputer.input_columns) + '_' + token,
+                                                tokens=token,
+                                                ngram_range=col_parms['ngram_range:' + token],
+                                                max_tokens=col_parms['max_tokens'])]
                 data_featurizers += [BowFeaturizer(field_name='-'.join(simple_imputer.input_columns) + '_' + token,
                                                    max_tokens=col_parms['max_tokens'])]
                 # mark unused parameter

--- a/datawig/_hpo.py
+++ b/datawig/_hpo.py
@@ -81,7 +81,7 @@ class _HPO:
         default_hps['string']['ngram_range']['chars'] = [(1, 5)]
 
         default_hps['categorical'] = {}
-        default_hps['categorical']['max_tokens'] = [2 ** 15, 2 ** 12]
+        default_hps['categorical']['max_tokens'] = [2 ** 12, 2 ** 15]
         default_hps['categorical']['embed_dim'] = [10]
 
         default_hps['numeric'] = {}

--- a/datawig/_hpo.py
+++ b/datawig/_hpo.py
@@ -64,23 +64,23 @@ class _HPO:
         # Define default hyperparameter choices for each column type (string, categorical, numeric)
         default_hps = dict()
         default_hps['global'] = {}
-        default_hps['global']['learning_rate'] = [3e-4]
+        default_hps['global']['learning_rate'] = [4e-3]
         default_hps['global']['weight_decay'] = [0, 1e-7]
         default_hps['global']['num_epochs'] = [100]
         default_hps['global']['patience'] = [5]
         default_hps['global']['batch_size'] = [16]
         default_hps['global']['final_fc_hidden_units'] = [[], [100]]
-        default_hps['global']['concat_columns'] = [True, False]
+        default_hps['global']['concat_columns'] = [False]
 
         default_hps['string'] = {}
         default_hps['string']['ngram_range'] = {}
         default_hps['string']['max_tokens'] = [2 ** 15]
-        default_hps['string']['tokens'] = [['words']]
+        default_hps['string']['tokens'] = [['chars']]
         default_hps['string']['ngram_range']['words'] = [(1, 3)]
         default_hps['string']['ngram_range']['chars'] = [(1, 5)]
 
         default_hps['categorical'] = {}
-        default_hps['categorical']['max_tokens'] = [2 ** 12, 2 ** 15]
+        default_hps['categorical']['max_tokens'] = [2 ** 15, 2 ** 12]
         default_hps['categorical']['embed_dim'] = [10]
 
         default_hps['numeric'] = {}

--- a/datawig/simple_imputer.py
+++ b/datawig/simple_imputer.py
@@ -51,8 +51,8 @@ class SimpleImputer:
     :param input_columns: list of input column names (as strings)
     :param output_column: output column name (as string)
     :param output_path: path to store model and metrics
-    :param num_hash_buckets: number of hash buckets used for the n-gram hashing vectorizer, only
-                                used for non-numerical input columns, ignored otherwise
+    :param num_hash_buckets: number of hash buckets used for the n-gram hashing vectorizer or max_tokens
+                                for the tfidf vectorizer, only used for non-numerical input columns, ignored otherwise.
     :param num_labels: number of imputable values considered after, only used for non-numerical
                         input columns, ignored otherwise
     :param tokens: string, 'chars' or 'words' (default 'chars'), determines tokenization strategy
@@ -62,7 +62,6 @@ class SimpleImputer:
     :param numeric_hidden_layers: number of numeric hidden layers
     :param is_explainable: if this is True, a stateful tf-idf encoder is used that allows
                            explaining classes and single instances
-
 
     Example usage:
 
@@ -232,7 +231,7 @@ class SimpleImputer:
             User can also pass in a list gpus to be used, ex. [mx.gpu(0), mx.gpu(2), mx.gpu(4)]
             This parameter is deprecated.s
 
-        :return: pd.DataFrame with with hyper-parameter configurations and results
+        :return: None
         """
 
         # generate dictionary with default hyperparameter settings. Overwrite these defaults

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="datawig",
-    version="0.1.6",
+    version="0.1.7",
     author="datawig-dev",
     author_email="datawig-dev@amazon.com",
     maintainer_email='datawig-dev@amazon.com',

--- a/test/test_simple_imputer.py
+++ b/test/test_simple_imputer.py
@@ -377,13 +377,13 @@ def test_hpo_all_input_types(test_dir, data_frame):
     imputer.fit_hpo(df_train,
                     hps=hps,
                     user_defined_scores=uds,
-                    num_evals=5,
+                    num_evals=3,
                     hpo_run_name='test1_')
 
     imputer.fit_hpo(df_train,
                     hps=hps,
                     user_defined_scores=uds,
-                    num_evals=5,
+                    num_evals=3,
                     hpo_run_name='test2_',
                     max_running_hours=1/3600)
 

--- a/test/test_simple_imputer.py
+++ b/test/test_simple_imputer.py
@@ -448,13 +448,13 @@ def test_hpo_many_columns(test_dir, data_frame):
                     n_samples=n_samples)
 
     for col in range(ncols):
-        df['string_featur_' + str(col)] = df['string_feature']
+        df['string_feature_' + str(col)] = df['string_feature']
 
     df_train, df_test = random_split(df, [.8, .2])
     output_path = os.path.join(test_dir, "tmp", "real_data_experiment_text_hpo")
 
     imputer = SimpleImputer(
-        input_columns=[col for col in df.columns if not col in ['label']],
+        input_columns=[col for col in df.columns if col not in ['label']],
         output_column='label',
         output_path=output_path
     )

--- a/test/test_simple_imputer.py
+++ b/test/test_simple_imputer.py
@@ -459,7 +459,11 @@ def test_hpo_many_columns(test_dir, data_frame):
         output_path=output_path
     )
 
-    imputer.fit_hpo(df_train, num_evals=2)
+    hps = {}
+    hps['global'] = {}
+    hps['global']['num_epochs'] = [10]
+
+    imputer.fit_hpo(df_train, hps=hps, num_evals=2)
 
     assert imputer.hpo.results.precision_weighted.max() > .8
 

--- a/test/test_simple_imputer.py
+++ b/test/test_simple_imputer.py
@@ -51,9 +51,9 @@ def test_simple_imputer_real_data_default_args(test_dir, data_frame):
     feature_col = "string_feature"
     label_col = "label"
 
-    n_samples = 2000
+    n_samples = 500
     num_labels = 3
-    seq_len = 100
+    seq_len = 30
     vocab_size = int(2 ** 15)
 
     # generate some random data
@@ -377,7 +377,7 @@ def test_hpo_all_input_types(test_dir, data_frame):
     imputer.fit_hpo(df_train,
                     hps=hps,
                     user_defined_scores=uds,
-                    num_evals=3,
+                    num_evals=2,
                     hpo_run_name='test1_')
 
     imputer.fit_hpo(df_train,
@@ -391,43 +391,6 @@ def test_hpo_all_input_types(test_dir, data_frame):
 
     assert results[results['global:num_epochs'] == 50]['f1_micro'].iloc[0] > \
            results[results['global:num_epochs'] == 5]['f1_micro'].iloc[0]
-
-    
-def test_hpo_defaults(test_dir, data_frame):
-    """
-
-    """
-    label_col = "label"
-
-    n_samples = 1000
-    num_labels = 3
-    seq_len = 10
-
-    # generate some random data
-    df = data_frame(feature_col="string_feature",
-                    label_col=label_col,
-                    num_labels=num_labels,
-                    num_words=seq_len,
-                    n_samples=n_samples)
-
-    # add categorical feature
-    df['categorical_feature'] = ['foo' if r > .5 else 'bar' for r in np.random.rand(n_samples)]
-
-    # add numerical feature
-    df['numeric_feature'] = np.random.rand(n_samples)
-
-    df_train, df_test = random_split(df, [.8, .2])
-    output_path = os.path.join(test_dir, "tmp", "real_data_experiment_text_hpo")
-
-    imputer = SimpleImputer(
-        input_columns=['string_feature', 'categorical_feature', 'numeric_feature'],
-        output_column='label',
-        output_path=output_path
-    )
-
-    imputer.fit_hpo(df_train, num_evals=2)
-
-    assert imputer.hpo.results.precision_weighted.max() > .7
 
 def test_hpo_many_columns(test_dir, data_frame):
     """


### PR DESCRIPTION
A few minor improvements to HPO
- Add new parameter ```hps['global']['is_explainable'] = [True, False]``` to select Hashing or TFIDF vectorizer. (Only the latter is explainable with ```.explain()```)
- When running repeated HPO, check whether each HPO configuration has previously been ran and skip configurations where results are already available.
- Improve docstrings.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
