### PR TITLE
HPO - remove data type dependent parameters

### DIFF
--- a/datawig/_hpo.py
+++ b/datawig/_hpo.py
@@ -234,7 +234,7 @@ class _HPO:
             label_column = [CategoricalEncoder(simple_imputer.output_column)]
             logger.info("Assuming categorical output column: {}".format(simple_imputer.output_column))
 
-        global_parms = {key.split(':')[1]: val for key, val in hp.iteritems() if 'global' in key}
+        global_parms = {key.split(':')[1]: val for key, val in hp.iteritems() if key.startswith('global:')}
 
         hp_time = time.time()
 

--- a/datawig/_hpo.py
+++ b/datawig/_hpo.py
@@ -64,36 +64,14 @@ class _HPO:
         self.output_path = None
 
         # Define default hyperparameter choices for each column type (string, categorical, numeric)
-        default_hps = dict()
-        default_hps['global'] = {}
-        default_hps['global']['learning_rate'] = [3e-4]
-        default_hps['global']['weight_decay'] = [1e-7]
-        default_hps['global']['num_epochs'] = [25]
-        default_hps['global']['patience'] = [5]
-        default_hps['global']['batch_size'] = [16]
-        default_hps['global']['final_fc_hidden_units'] = [[]]
-        default_hps['global']['concat_columns'] = [False]
-
-        default_hps['string'] = {}
-        default_hps['string']['ngram_range'] = {}
-        default_hps['string']['max_tokens'] = [2 ** 15]
-        default_hps['string']['tokens'] = [['words']]
-        default_hps['string']['ngram_range']['words'] = [(1, 3)]
-        default_hps['string']['ngram_range']['chars'] = [(1, 5)]
-
-        default_hps['categorical'] = {}
-        default_hps['categorical']['max_tokens'] = [2 ** 12]
-        default_hps['categorical']['embed_dim'] = [10]
-
-        default_hps['numeric'] = {}
-        default_hps['numeric']['normalize'] = [True]
-        default_hps['numeric']['numeric_latent_dim'] = [10]
-        default_hps['numeric']['numeric_hidden_layers'] = [1]
-
-        # parameters for a single column of concatenated strings
-        default_hps['concat'] = default_hps['string'].copy()
-
-        self.default_hps = default_hps
+        self.default_hps = dict()
+        self.default_hps['global'] = {}
+        self.default_hps['global']['learning_rate'] = [3e-4]
+        self.default_hps['global']['weight_decay'] = [1e-7]
+        self.default_hps['global']['num_epochs'] = [25]
+        self.default_hps['global']['patience'] = [5]
+        self.default_hps['global']['batch_size'] = [16]
+        self.default_hps['global']['final_fc_hidden_units'] = [[]]
 
     def __preprocess_hps(self,
                          train_df: pd.DataFrame,
@@ -111,13 +89,26 @@ class _HPO:
                     Column names have the form colum:parameter, e.g. title:max_tokens or global:learning rate.
         """
 
+        default_hps = dict()
+        default_hps['string'] = {}
+        default_hps['string']['ngram_range'] = {}
+        default_hps['string']['max_tokens'] = [2 ** 15]
+        default_hps['string']['tokens'] = [['words']]
+        default_hps['string']['ngram_range']['words'] = [(1, 3)]
+        default_hps['string']['ngram_range']['chars'] = [(1, 5)]
+
+        default_hps['categorical'] = {}
+        default_hps['categorical']['max_tokens'] = [2 ** 12]
+        default_hps['categorical']['embed_dim'] = [10]
+
+        default_hps['numeric'] = {}
+        default_hps['numeric']['normalize'] = [True]
+        default_hps['numeric']['numeric_latent_dim'] = [10]
+        default_hps['numeric']['numeric_hidden_layers'] = [1]
+
         # create empty dict if global hps not passed
         if 'global' not in self.hps.keys():
             self.hps['global'] = {}
-
-        # create empty dict if parameters for concatenated column not passed
-        if 'concat' not in self.hps.keys():
-            self.hps['concat'] = {}
 
         # add type to column dictionaries if it was not specified, does not support categorical types
         for column_name in simple_imputer.input_columns:
@@ -129,44 +120,24 @@ class _HPO:
                 else:
                     self.hps[column_name]['type'] = ['string']
 
-        # check that all passed parameter are valid hyperparameters
-        assert all([key in self.default_hps['global'].keys() for key in self.hps['global'].keys()])
-        for key, val in self.hps.items():
-            if 'type' in val.keys():
-                assert all([key in list(self.default_hps[val['type'][0]].keys()) + ['type'] for key, _ in val.items()])
+            # merge column hyper parameters with feature type specific defaults
+            for parameter_key, values in default_hps[self.hps[column_name]['type'][0]].items():
+                if parameter_key not in self.hps[column_name]:
+                    self.hps[column_name][parameter_key] = values
 
-        # augment provided global self.hps with default global hps so that cartesian products are full parameter sets.
-        # self.hps['global'] = {**self.default_hps['global'], **self.hps['global']}
-        self.hps['global'] = merge_dicts(self.default_hps['global'], self.hps['global'])
-        self.hps['concat'] = merge_dicts(self.default_hps['concat'], self.hps['concat'])
-
-        # augment provided self.hps with default self.hps, iterating over every input column
-        for column_name in simple_imputer.input_columns:
-            # add dictionary for input columns where no hyperparamters have been passed
-            if column_name not in self.hps.keys():
-                self.hps[column_name] = {}
-                if column_name in simple_imputer.numeric_columns:
-                    self.hps[column_name]['type'] = ['numeric']
-                elif column_name in simple_imputer.string_columns:
-                    self.hps[column_name]['type'] = ['string']
-                else:
-                    logger.warn('Input type of column ' + str(column_name) + ' not determined.')
-            # join all column specific hp dictionaries with type-specific default values
-            # self.hps[column_name] = {**self.default_hps[self.hps[column_name]['type'][0]], **self.hps[column_name]}
-
-            # delete intersection keys from default hps
-            default_type_hps = self.default_hps[self.hps[column_name]['type'][0]].copy()
-            type_hps = self.hps[self.hps[column_name]['type'][0]]
-            # specified data type hps have precedence over default ones
-            shared_keys = set(default_type_hps.keys()).intersection(set(type_hps.keys()))
-            for key in shared_keys:
-                del default_type_hps[key]
-
-            self.hps[column_name] = merge_dicts(merge_dicts(default_type_hps, type_hps), self.hps[column_name])
+        # merge global parameters with defaults
+        for parameter_key, values in self.default_hps['global'].items():
+            if parameter_key not in self.hps['global']:
+                self.hps['global'][parameter_key] = values
 
         flat_dict = flatten_dict(self.hps)
-        hp_df = pd.DataFrame(random_cartesian_product([val for key, val in flat_dict.items()], num=num_evals),
-                             columns=flat_dict.keys())
+
+        values = [value for key, value in flat_dict.items()]
+        keys = [key for key in flat_dict.keys()]
+        hp_df = pd.DataFrame(
+            random_cartesian_product(values, num=num_evals),
+            columns=keys
+        )
 
         return hp_df
 
@@ -216,69 +187,42 @@ class _HPO:
         data_encoders = []
         data_featurizers = []
 
-        if hp['global:concat_columns'] is False:
+        # define column encoders and featurisers for each input column
+        for input_column in simple_imputer.input_columns:
 
-            # mark unused parameter
-            for key, val in hp.items():
-                if 'concat:' in key:
-                    hp[key] = 'n.a.'
+            # extract parameters for the current input column, take everything after the first colon
+            col_parms = {':'.join(key.split(':')[1:]): val for key, val in hp.items() if input_column in key}
 
-            # define column encoders and featurisers for each input column
-            for input_column in simple_imputer.input_columns:
-
-                # extract parameters for the current input column, take everything after the first colon
-                col_parms = {':'.join(key.split(':')[1:]): val for key, val in hp.items() if input_column in key}
-
-                # define all input columns
-                if col_parms['type'] == 'string':
-                    # iterate over multiple embeddings (chars + strings for the same column)
-                    for token in col_parms['tokens']:
-                        # call kw. args. with: **{key: item for key, item in col_parms.items() if not key == 'type'})]
-                        data_encoders += [TfIdfEncoder(input_columns=[input_column],
-                                                       output_column=input_column + '_' + token,
-                                                       tokens=token,
-                                                       ngram_range=col_parms['ngram_range:'+token],
-                                                       max_tokens=col_parms['max_tokens'])]
-                        data_featurizers += [BowFeaturizer(field_name=input_column + '_' + token,
-                                                           max_tokens=col_parms['max_tokens'])]
-
-                elif col_parms['type'] == 'categorical':
-                    data_encoders += [CategoricalEncoder(input_columns=[input_column],
-                                                         output_column=input_column + '_' + col_parms['type'],
-                                                         max_tokens=col_parms['max_tokens'])]
-                    data_featurizers += [EmbeddingFeaturizer(field_name=input_column + '_' + col_parms['type'],
-                                                             max_tokens=col_parms['max_tokens'],
-                                                             embed_dim=col_parms['embed_dim'])]
-
-                elif col_parms['type'] == 'numeric':
-                    data_encoders += [NumericalEncoder(input_columns=[input_column],
-                                                       output_column=input_column + '_' + col_parms['type'],
-                                                       normalize=col_parms['normalize'])]
-                    data_featurizers += [NumericalFeaturizer(field_name=input_column + '_' + col_parms['type'],
-                                                             numeric_latent_dim=col_parms['numeric_latent_dim'],
-                                                             numeric_hidden_layers=col_parms['numeric_hidden_layers'])]
-                else:
-                    logger.warn('Found unknown column type. Canidates are string, categorical, numeric.')
-
-        # Concatenate all columns
-        else:
-            # cast all columns to string for concatenation
-            train_df = train_df.astype(str)
-            test_df = test_df.astype(str)
-
-            col_parms = {':'.join(key.split(':')[1:]): val for key, val in hp.items() if 'concat' in key}
-            for token in col_parms['tokens']:
-                data_encoders += [TfIdfEncoder(input_columns=simple_imputer.input_columns,
-                                               output_column='-'.join(simple_imputer.input_columns) + '_' + token,
-                                               tokens=token,
-                                               ngram_range=col_parms['ngram_range:' + token],
-                                               max_tokens=col_parms['max_tokens'])]
-                data_featurizers += [BowFeaturizer(field_name='-'.join(simple_imputer.input_columns) + '_' + token,
+            # define all input columns
+            if col_parms['type'] == 'string':
+                # iterate over multiple embeddings (chars + strings for the same column)
+                for token in col_parms['tokens']:
+                    # call kw. args. with: **{key: item for key, item in col_parms.items() if not key == 'type'})]
+                    data_encoders += [TfIdfEncoder(input_columns=[input_column],
+                                                   output_column=input_column + '_' + token,
+                                                   tokens=token,
+                                                   ngram_range=col_parms['ngram_range:'+token],
                                                    max_tokens=col_parms['max_tokens'])]
-                # mark unused parameter
-                for key, val in hp.items():
-                    if not ('global:' in key or 'concat:' in key):
-                        hp[key] = 'n.a.'
+                    data_featurizers += [BowFeaturizer(field_name=input_column + '_' + token,
+                                                       max_tokens=col_parms['max_tokens'])]
+
+            elif col_parms['type'] == 'categorical':
+                data_encoders += [CategoricalEncoder(input_columns=[input_column],
+                                                     output_column=input_column + '_' + col_parms['type'],
+                                                     max_tokens=col_parms['max_tokens'])]
+                data_featurizers += [EmbeddingFeaturizer(field_name=input_column + '_' + col_parms['type'],
+                                                         max_tokens=col_parms['max_tokens'],
+                                                         embed_dim=col_parms['embed_dim'])]
+
+            elif col_parms['type'] == 'numeric':
+                data_encoders += [NumericalEncoder(input_columns=[input_column],
+                                                   output_column=input_column + '_' + col_parms['type'],
+                                                   normalize=col_parms['normalize'])]
+                data_featurizers += [NumericalFeaturizer(field_name=input_column + '_' + col_parms['type'],
+                                                         numeric_latent_dim=col_parms['numeric_latent_dim'],
+                                                         numeric_hidden_layers=col_parms['numeric_hidden_layers'])]
+            else:
+                logger.warn('Found unknown column type. Canidates are string, categorical, numeric.')
 
         # Define separate encoder and featurizer for each column
         # Define output column. Associated parameters are not tuned.
@@ -341,8 +285,9 @@ class _HPO:
             hp['ece_post_calibration'] = hp_imputer.calibration_info['ece_post']
             hp['time [min]'] = (time.time() - hp_time)/60
 
-        for uds in user_defined_scores:
-            hp[uds[1]] = uds[0](true=true, predicted=predicted, confidence=confidence)
+        if user_defined_scores:
+            for uds in user_defined_scores:
+                hp[uds[1]] = uds[0](true=true, predicted=predicted, confidence=confidence)
 
         hp_imputer.save()
 
@@ -352,15 +297,14 @@ class _HPO:
              train_df: pd.DataFrame,
              test_df: pd.DataFrame = None,
              hps: dict = None,
-             strategy: str = 'random',
              num_evals: int = 10,
              max_running_hours: float = 96,
              user_defined_scores: list = None,
              hpo_run_name: str = None,
-             simple_imputer = None):
+             simple_imputer=None):
 
         """
-        Do grid search or random search for hyperparameter configurations. This method can not tune tfidf vs hashing
+        Do random search for hyper parameter configurations. This method can not tune tfidf vs hashing
         vectorization but uses tfidf. Also parameters of the output column encoder are not tuned.
         
         :param train_df: training data as dataframe
@@ -371,7 +315,6 @@ class _HPO:
                           Further, hps[column_name]['type'] is in ['numeric', 'categorical', 'string'] and is
                           inferred if not provided. See init method of HPO for further details.
 
-        :param strategy: 'random' for random search or 'grid' for exhaustive search
         :param num_evals: number of evaluations for random search
         :param max_running_hours: Time before the hpo run is terminated in hours
         :param user_defined_scores: list with entries (Callable, str), where callable is a function
@@ -412,7 +355,6 @@ class _HPO:
                 logger.info('Finishing hpo because max running time was reached.')
                 break
 
-            # if concat_columns True, set all n.a. hps to n.a. TODO
             logger.info("Fitting hpo iteration " + str(hp_idx) + " with parameters\n\t" +
                         '\n\t'.join([str(i) + ': ' + str(j) for i, j in hp.items()]))
             name = hpo_run_name + str(hp_idx)
@@ -437,4 +379,5 @@ class _HPO:
             elapsed_time = (time.time() - start_time)/3600
 
         logger.info('Assigning model with highest weighted precision to SimpleImputer object and copying artifacts.')
+        simple_imputer.hpo = self
         simple_imputer.load_hpo_model()  # assign best model to simple_imputer.imputer and write artifacts.

--- a/datawig/_hpo.py
+++ b/datawig/_hpo.py
@@ -18,23 +18,18 @@ Implements hyperparameter optimisation for datawig
 
 """
 
-import itertools
-import time
-import random
 import os
-
-import numpy as np
-import pandas as pd
-
+import time
 from datetime import datetime
-from pandas.api.types import is_numeric_dtype
-from sklearn.metrics import mean_squared_error, f1_score, precision_score, accuracy_score, recall_score
 
-from .column_encoders import BowEncoder, CategoricalEncoder, NumericalEncoder, ColumnEncoder, TfIdfEncoder
-from .mxnet_input_symbols import BowFeaturizer, NumericalFeaturizer, Featurizer, EmbeddingFeaturizer
-from .utils import logger, get_context, random_split, rand_string, flatten_dict, merge_dicts
+import pandas as pd
+from pandas.api.types import is_numeric_dtype
+from sklearn.metrics import mean_squared_error, f1_score, recall_score
 
 from datawig.utils import random_cartesian_product
+from .column_encoders import CategoricalEncoder, NumericalEncoder, TfIdfEncoder
+from .mxnet_input_symbols import BowFeaturizer, NumericalFeaturizer, EmbeddingFeaturizer
+from .utils import logger, get_context, random_split, flatten_dict
 
 
 class _HPO:
@@ -51,12 +46,8 @@ class _HPO:
     """
 
     def __init__(self):
-
         """
         Init method also defines default hyperparameter choices, global and for each input column type.
-
-        :param imputer: SimpleImputer instance with input_colums and output_column and output_path specified.
-
         """
 
         self.hps = None

--- a/datawig/simple_imputer.py
+++ b/datawig/simple_imputer.py
@@ -165,7 +165,6 @@ class SimpleImputer:
                 train_df: pd.DataFrame,
                 test_df: pd.DataFrame = None,
                 hps: dict = None,
-                strategy: str = 'random',
                 num_evals: int = 10,
                 max_running_hours: float = 96.0,
                 hpo_run_name: str = None,
@@ -186,8 +185,7 @@ class SimpleImputer:
                 ctx: mx.context = get_context()) -> Any:
 
         """
-
-        Fits an imputer model with gridsearch hyperparameter optimization (hpo)
+        Fits an imputer model with hyperparameter optimization. The parameter ranges are searched randomly.
 
         Grids are specified using the *_candidates arguments (old)
         or with more flexibility via the dictionary hps.
@@ -199,7 +197,6 @@ class SimpleImputer:
             hps[column_name][parameter_name] is a list of parameter values for each input column.
             Further, hps[column_name]['type'] is in ['numeric', 'categorical', 'string'] and is
             inferred if not provided.
-        :param strategy: 'random' for random search or 'grid' for exhaustive search
         :param num_evals: number of evaluations for random search
         :param max_running_hours: Time before the hpo run is terminated in hours.
         :param hpo_run_name: string to identify the current hpo run.
@@ -230,7 +227,7 @@ class SimpleImputer:
             use is deprecated.
         :param ctx: List of mxnet contexts (if no gpu's available, defaults to [mx.cpu()])
             User can also pass in a list gpus to be used, ex. [mx.gpu(0), mx.gpu(2), mx.gpu(4)]
-            This parameter is deprecated.s
+            This parameter is deprecated.
 
         :return: pd.DataFrame with with hyper-parameter configurations and results
         """
@@ -290,7 +287,7 @@ class SimpleImputer:
             train_df, test_df = random_split(train_df, [1-test_split, test_split])
 
         self.check_data_types(train_df)  # infer data types, saved self.string_columns, self.numeric_columns
-        self.hpo.tune(train_df, test_df, hps, strategy, num_evals,
+        self.hpo.tune(train_df, test_df, hps, num_evals,
                       max_running_hours, user_defined_scores, hpo_run_name, self)
         self.save()
 

--- a/datawig/simple_imputer.py
+++ b/datawig/simple_imputer.py
@@ -249,11 +249,11 @@ class SimpleImputer:
         if batch_size:
             default_hps['global']['batch_size'] = [batch_size]
         if final_fc_hidden_units:
-            default_hps['global']['final_fc_hidden_units'] = [final_fc_hidden_units]
+            default_hps['global']['final_fc_hidden_units'] = final_fc_hidden_units
 
         default_hps['string'] = {}
         if num_hash_bucket_candidates:
-            default_hps['string']['max_tokens'] = [num_hash_bucket_candidates]
+            default_hps['string']['max_tokens'] = num_hash_bucket_candidates
 
         if tokens_candidates:
             default_hps['string']['tokens'] = [[c] for c in tokens_candidates]
@@ -266,10 +266,10 @@ class SimpleImputer:
         if normalize_numeric:
             default_hps['numeric']['normalize'] = [normalize_numeric]
         if numeric_latent_dim_candidates:
-            default_hps['numeric']['numeric_latent_dim'] = [numeric_latent_dim_candidates]
+            default_hps['numeric']['numeric_latent_dim'] = numeric_latent_dim_candidates
 
         if numeric_hidden_layers_candidates:
-            default_hps['numeric']['numeric_hidden_layers'] = [numeric_hidden_layers_candidates]
+            default_hps['numeric']['numeric_hidden_layers'] = numeric_hidden_layers_candidates
 
         if hps is None:
             hps = {}
@@ -287,8 +287,7 @@ class SimpleImputer:
             train_df, test_df = random_split(train_df, [1-test_split, test_split])
 
         self.check_data_types(train_df)  # infer data types, saved self.string_columns, self.numeric_columns
-        self.hpo.tune(train_df, test_df, hps, num_evals,
-                      max_running_hours, user_defined_scores, hpo_run_name, self)
+        self.hpo.tune(train_df, test_df, hps, num_evals, max_running_hours, user_defined_scores, hpo_run_name, self)
         self.save()
 
     def fit(self,

--- a/datawig/simple_imputer.py
+++ b/datawig/simple_imputer.py
@@ -237,9 +237,9 @@ class SimpleImputer:
         default_hps = dict()
         default_hps['global'] = dict()
         if learning_rate_candidates:
-            default_hps['global']['learning_rate'] = [learning_rate_candidates]
+            default_hps['global']['learning_rate'] = learning_rate_candidates
         if weight_decay:
-            default_hps['global']['weight_decay'] = [weight_decay]
+            default_hps['global']['weight_decay'] = weight_decay
         if num_epochs:
             default_hps['global']['num_epochs'] = [num_epochs]
 

--- a/docs/source/userguide.rst
+++ b/docs/source/userguide.rst
@@ -248,13 +248,12 @@ The steps for training a model with HPO are identical to the default :code:`Simp
         output_path='imputer_model'
     )
 
-    #Fit an imputer model with customized hyperparameters
+    # fit an imputer model with customized hyperparameters
     imputer.fit_hpo(
         train_df=df_train,
         num_epochs=100,
         patience=3,
-        learning_rate_candidates=[1e-3, 3e-4, 1e-4],
-        hpo_max_train_samples=1000
+        learning_rate_candidates=[1e-3, 3e-4, 1e-4]
     )
 
 See the SimpleImputer_ for more details on parameters.

--- a/examples/imputer_intro.py
+++ b/examples/imputer_intro.py
@@ -23,49 +23,49 @@ Load Data
 df = pd.read_csv('../finish_val_data_sample.csv')
 df_train, df_test = random_split(df, split_ratios=[0.8, 0.2])
 
-#------------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------------
 
 '''
 Run default Imputer
 '''
 data_encoder_cols = [BowEncoder('title'),
-					 BowEncoder('text')]
+                     BowEncoder('text')]
 label_encoder_cols = [CategoricalEncoder('finish')]
 data_featurizer_cols = [BowFeaturizer('title'),
-						BowFeaturizer('text')]
+                        BowFeaturizer('text')]
 
 imputer = Imputer(
-	data_featurizers=data_featurizer_cols,
-	label_encoders=label_encoder_cols,
-	data_encoders=data_encoder_cols,
-	output_path='imputer_model'
-	)
+    data_featurizers=data_featurizer_cols,
+    label_encoders=label_encoder_cols,
+    data_encoders=data_encoder_cols,
+    output_path='imputer_model'
+)
 
 imputer.fit(train_df=df_train)
 predictions = imputer.predict(df_test)
 
-#------------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------------
 
 '''
 Specifying Encoders and Featurizers
 '''
 data_encoder_cols = [SequentialEncoder('title'),
-					 SequentialEncoder('text')]
+                     SequentialEncoder('text')]
 label_encoder_cols = [CategoricalEncoder('finish')]
 data_featurizer_cols = [LSTMFeaturizer('title'),
-						LSTMFeaturizer('text')]
+                        LSTMFeaturizer('text')]
 
 imputer = Imputer(
-	data_featurizers=data_featurizer_cols,
-	label_encoders=label_encoder_cols,
-	data_encoders=data_encoder_cols,
-	output_path='imputer_model'
-	)
+    data_featurizers=data_featurizer_cols,
+    label_encoders=label_encoder_cols,
+    data_encoders=data_encoder_cols,
+    output_path='imputer_model'
+)
 
 imputer.fit(train_df=df_train)
 predictions = imputer.predict(df_test)
 
-#------------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------------
 
 '''
 Run Imputer with predict_proba/predict_proba_top_k
@@ -73,10 +73,9 @@ Run Imputer with predict_proba/predict_proba_top_k
 prob_dict = imputer.predict_proba(df_test)
 prob_dict_topk = imputer.predict_proba_top_k(df_test, top_k=5)
 
-#------------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------------
 
 '''
 Run Imputer with transform_and_compute_metrics
 '''
 predictions, metrics = imputer.transform_and_compute_metrics(df_test)
-

--- a/examples/simpleimputer_intro.py
+++ b/examples/simpleimputer_intro.py
@@ -27,23 +27,23 @@ df_train, df_test = random_split(df, split_ratios=[0.8, 0.2])
 '''
 Run default SimpleImputer
 '''
-#Initialize a SimpleImputer model
+# Initialize a SimpleImputer model
 imputer = SimpleImputer(
     input_columns=['title', 'text'], #columns containing information about the column we want to impute
     output_column='finish', #the column we'd like to impute values for
-    output_path = 'imputer_model' #stores model data and metrics
-    )
+    output_path='imputer_model' #stores model data and metrics
+)
 
-#Fit an imputer model on the train data 
+# Fit an imputer model on the train data
 imputer.fit(train_df=df_train)
 
-#Impute missing values and return original dataframe with predictions
+# Impute missing values and return original dataframe with predictions
 predictions = imputer.predict(df_test)
 
-#Calculate f1 score for true vs predicted values
+# Calculate f1 score for true vs predicted values
 f1 = f1_score(predictions['finish'], predictions['finish_imputed'], average='weighted')
 
-#Print overall classification report
+# Print overall classification report
 print(classification_report(predictions['finish'], predictions['finish_imputed']))
 
 #------------------------------------------------------------------------------------
@@ -51,37 +51,36 @@ print(classification_report(predictions['finish'], predictions['finish_imputed']
 '''
 Run SimpleImputer with hyperparameter optimization
 '''
-#Initialize a SimpleImputer model
+# Initialize a SimpleImputer model
 imputer = SimpleImputer(
     input_columns=['title', 'text'],
     output_column='finish',
-    output_path = 'imputer_model'
-    )
+    output_path='imputer_model'
+)
 
-#Fit an imputer model with default list of hyperparameters
+# Fit an imputer model with default list of hyperparameters
 imputer.fit_hpo(train_df=df_train)
 
-#Fit an imputer model with customized HPO
+# Fit an imputer model with customized HPO
 imputer.fit_hpo(
-        train_df=df_train,
-        num_epochs=50,
-        patience=3,
-        learning_rate_candidates=[1e-3, 1e-4],
-        num_hash_bucket_candidates = [2 ** 15],
-        tokens_candidates = ['words', 'chars'],
-        hpo_max_train_samples=300
-    	)
+    train_df=df_train,
+    num_epochs=50,
+    patience=3,
+    learning_rate_candidates=[1e-3, 1e-4],
+    num_hash_bucket_candidates=[2 ** 15],
+    tokens_candidates=['words', 'chars']
+)
 
 #------------------------------------------------------------------------------------
 
 '''
 Load saved model and get metrics from SimpleImputer
 '''
-#Load saved model
+# Load saved model
 imputer = SimpleImputer.load('./imputer_model')
 
-#Load a dictionary of metrics from the validation set
+# Load a dictionary of metrics from the validation set
 metrics = imputer.load_metrics()
 weighted_f1 = metrics['weighted_f1']
 avg_precision = metrics['avg_precision']
-#... explore other metrics stored in this dictionary!
+# ... explore other metrics stored in this dictionary!

--- a/test/test_hpo.py
+++ b/test/test_hpo.py
@@ -1,0 +1,44 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not
+# use this file except in compliance with the License. A copy of the License
+# is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+from datawig._hpo import _HPO
+from datawig.simple_imputer import SimpleImputer
+
+
+def test_single_hpo(test_dir, data_frame):
+    feature_col, label_col = "feature", "label"
+
+    df = data_frame(feature_col=feature_col,
+                    label_col=label_col)
+
+    imputer = SimpleImputer(
+        input_columns=[col for col in df.columns if col != label_col],
+        output_column=label_col,
+        output_path=test_dir
+    )
+
+    hps = dict()
+    hps[feature_col] = {'max_tokens': [1024]}
+    hps['global'] = {}
+    hps['global']['num_epochs'] = [10]
+
+    hpo = _HPO()
+    hpo.tune(
+        train_df=df,
+        hps=hps,
+        simple_imputer=imputer
+    )
+
+    assert hpo.results.shape[0] == 1
+    assert hpo.results[feature_col+':max_tokens'].values[0] == 1024
+    assert hpo.results['global:num_epochs'].values[0] == 10

--- a/test/test_hpo.py
+++ b/test/test_hpo.py
@@ -31,6 +31,9 @@ def test_single_hpo(test_dir, data_frame):
     hps[feature_col] = {'max_tokens': [1024]}
     hps['global'] = {}
     hps['global']['num_epochs'] = [10]
+    hps['string'] = {}
+    hps['categorical'] = {}
+    hps['numeric'] = {}
 
     hpo = _HPO()
     hpo.tune(

--- a/test/test_simple_imputer.py
+++ b/test/test_simple_imputer.py
@@ -765,16 +765,14 @@ def test_hpo_similar_input_col_mixed_types(test_dir, data_frame):
 def test_hpo_kwargs_only_support(test_dir, data_frame):
     feature_col, label_col = "feature", "label"
     numeric_col = "numeric_feature"
-    categorical_col = "categorical_col"
 
     df = data_frame(feature_col=feature_col,
                     label_col=label_col)
 
     df.loc[:, numeric_col] = np.random.randn(df.shape[0])
-    df.loc[:, categorical_col] = np.random.randint(df.shape[0])
 
     imputer = SimpleImputer(
-        input_columns=[feature_col, numeric_col, categorical_col],
+        input_columns=[feature_col, numeric_col],
         output_column=label_col,
         output_path=test_dir
     )

--- a/test/test_simple_imputer.py
+++ b/test/test_simple_imputer.py
@@ -231,7 +231,7 @@ def test_imputer_hpo_numeric(test_dir):
 
     feature_col = 'x'
 
-    hps = {}
+    hps = dict()
     hps[feature_col] = {}
     hps[feature_col]['type'] = ['numeric']
     hps[feature_col]['numeric_latent_dim'] = [30]
@@ -243,7 +243,6 @@ def test_imputer_hpo_numeric(test_dir):
     hps['global']['weight_decay'] = [0]
     hps['global']['num_epochs'] = [200]
     hps['global']['patience'] = [100]
-    hps['global']['concat_columns'] = [False]
 
     imputer_numeric.fit_hpo(df_train, hps=hps)
     results = imputer_numeric.hpo.results
@@ -281,7 +280,7 @@ def test_imputer_hpo_text(test_dir, data_frame):
         output_path=output_path
     )
 
-    hps = {}
+    hps = dict()
     hps[feature_col] = {}
     hps[feature_col]['type'] = ['string']
     hps[feature_col]['tokens'] = [['words'], ['chars']]
@@ -340,7 +339,6 @@ def test_hpo_all_input_types(test_dir, data_frame):
     hps['global']['patience'] = [5]
     hps['global']['batch_size'] = [16]
     hps['global']['final_fc_hidden_units'] = [[]]
-    hps['global']['concat_columns'] = [True, False]
 
     hps['string_feature'] = {}
     hps['string_feature']['max_tokens'] = [2 ** 15]
@@ -394,9 +392,6 @@ def test_hpo_all_input_types(test_dir, data_frame):
 
     
 def test_hpo_defaults(test_dir, data_frame):
-    """
-
-    """
     label_col = "label"
 
     n_samples = 1000
@@ -429,11 +424,52 @@ def test_hpo_defaults(test_dir, data_frame):
 
     assert imputer.hpo.results.precision_weighted.max() > .5
 
-def test_hpo_many_columns(test_dir, data_frame):
-    """
 
-    """
-    label_col = "label"
+def test_hpo_num_evals_empty_hps(test_dir, data_frame):
+    feature_col, label_col = "feature", "label"
+
+    # generate some random data
+    df = data_frame(feature_col=feature_col,
+                    label_col=label_col)
+
+    imputer = SimpleImputer(
+        input_columns=[col for col in df.columns if col != label_col],
+        output_column=label_col,
+        output_path=test_dir
+    )
+
+    num_evals = 2
+    imputer.fit_hpo(df, num_evals=num_evals)
+
+    assert imputer.hpo.results.shape[0] == 1
+
+
+def test_hpo_num_evals_given_hps(test_dir, data_frame):
+    feature_col, label_col = "feature", "label"
+
+    # generate some random data
+    df = data_frame(feature_col=feature_col,
+                    label_col=label_col)
+
+    num_evals = 2
+    # assert that num_evals is an upper bound on the number of hpo runs
+    for n_max_tokens_to_try in range(1, 5):
+        imputer = SimpleImputer(
+            input_columns=[col for col in df.columns if col != label_col],
+            output_column=label_col,
+            output_path=test_dir
+        )
+
+        hps = {
+            feature_col: {'max_tokens': n_max_tokens_to_try*[10]}
+        }
+        imputer.fit_hpo(df, hps=hps, num_evals=num_evals)
+
+        assert imputer.hpo.results.shape[0] == min(num_evals, n_max_tokens_to_try)
+
+
+def test_hpo_many_columns(test_dir, data_frame):
+    feature_col, label_col = "feature", "label"
 
     n_samples = 300
     num_labels = 3
@@ -441,25 +477,22 @@ def test_hpo_many_columns(test_dir, data_frame):
     seq_len = 4
 
     # generate some random data
-    df = data_frame(feature_col="string_feature",
+    df = data_frame(feature_col=feature_col,
                     label_col=label_col,
                     num_labels=num_labels,
                     num_words=seq_len,
                     n_samples=n_samples)
 
     for col in range(ncols):
-        df['string_featur_' + str(col)] = df['string_feature']
-
-    df_train, df_test = random_split(df, [.8, .2])
-    output_path = os.path.join(test_dir, "tmp", "real_data_experiment_text_hpo")
+        df[feature_col + '_' + str(col)] = df[feature_col]
 
     imputer = SimpleImputer(
         input_columns=[col for col in df.columns if not col in ['label']],
-        output_column='label',
-        output_path=output_path
+        output_column=label_col,
+        output_path=test_dir
     )
 
-    imputer.fit_hpo(df_train, num_evals=2)
+    imputer.fit_hpo(df, num_evals=2)
 
     assert imputer.hpo.results.precision_weighted.max() > .75
 
@@ -598,140 +631,73 @@ def test_explainable_simple_imputer(test_dir, data_frame):
 
 
 def test_hpo_runs(test_dir, data_frame):
-    label_col = "label"
+    feature_col, label_col = "feature", "label"
 
-    n_samples = 300
-    num_labels = 3
-    seq_len = 4
-
-    # generate some random data
-    df = data_frame(feature_col="string_feature",
-                    label_col=label_col,
-                    num_labels=num_labels,
-                    num_words=seq_len,
-                    n_samples=n_samples)
-
-    df_train, df_test = random_split(df, [.8, .2])
-    output_path = os.path.join(test_dir, "tmp", "real_data_experiment_text_hpo")
+    df = data_frame(feature_col=feature_col,
+                    label_col=label_col)
 
     imputer = SimpleImputer(
         input_columns=[col for col in df.columns if col != label_col],
         output_column=label_col,
-        output_path=output_path
+        output_path=test_dir
     )
 
-    hps = {}
-    hps['string_feature'] = {'max_tokens': [1024, 2048]}
+    hps = dict()
+    max_tokens = [1024, 2048]
+    hps[feature_col] = {'max_tokens': max_tokens}
     hps['global'] = {}
     hps['global']['concat_columns'] = [False]
     hps['global']['num_epochs'] = [10]
 
-    imputer.fit_hpo(df_train, hps=hps)
+    imputer.fit_hpo(df, hps=hps)
 
     # only search over specified parameter ranges
+    assert set(imputer.hpo.results[feature_col+':'+'max_tokens'].unique().tolist()) == set(max_tokens)
     assert imputer.hpo.results.shape[0] == 2
 
 
-def test_hpo_feature_specific_setting(test_dir, data_frame):
-    label_col = "label"
+def test_hpo_single_column_encoder_parameter(test_dir, data_frame):
+    feature_col, label_col = "feature", "label"
 
-    n_samples = 300
-    num_labels = 3
-    seq_len = 4
-
-    # generate some random data
-    df = data_frame(feature_col="string_feature",
-                    label_col=label_col,
-                    num_labels=num_labels,
-                    num_words=seq_len,
-                    n_samples=n_samples)
-
-    df_train, df_test = random_split(df, [.8, .2])
-    output_path = os.path.join(test_dir, "tmp", "real_data_experiment_text_hpo")
+    df = data_frame(feature_col=feature_col,
+                    label_col=label_col)
 
     imputer = SimpleImputer(
         input_columns=[col for col in df.columns if col != label_col],
         output_column=label_col,
-        output_path=output_path
+        output_path=test_dir
     )
 
-    hps = {}
-    hps['string_feature'] = {'max_tokens': [1024]}
+    hps = dict()
+    hps[feature_col] = {'max_tokens': [1024]}
     hps['global'] = {}
-    hps['global']['concat_columns'] = [False]
     hps['global']['num_epochs'] = [10]
 
-    imputer.fit_hpo(df_train, hps=hps)
+    imputer.fit_hpo(df, hps=hps)
 
     assert imputer.hpo.results.shape[0] == 1
     assert imputer.imputer.data_encoders[0].vectorizer.max_features == 1024
 
 
-def test_hpo_feature_type_setting(test_dir, data_frame):
-    label_col = "label"
+def test_hpo_multiple_columns_only_one_used(test_dir, data_frame):
+    feature_col, label_col = "feature", "label"
 
-    n_samples = 300
-    num_labels = 3
-    seq_len = 4
-
-    # generate some random data
-    df = data_frame(feature_col="string_feature",
-                    label_col=label_col,
-                    num_labels=num_labels,
-                    num_words=seq_len,
-                    n_samples=n_samples)
-
-    df_train, df_test = random_split(df, [.8, .2])
-    output_path = os.path.join(test_dir, "tmp", "real_data_experiment_text_hpo")
+    df = data_frame(feature_col=feature_col,
+                    label_col=label_col)
+    df.loc[:, feature_col+'_2'] = df.loc[:, feature_col]
 
     imputer = SimpleImputer(
-        input_columns=[col for col in df.columns if col != label_col],
+        input_columns=[feature_col],
         output_column=label_col,
-        output_path=output_path
+        output_path=test_dir
     )
 
-    hps = {}
-    hps['string'] = {'max_tokens': [512]}
+    hps = dict()
+    hps[feature_col] = {'max_tokens': [1024]}
     hps['global'] = {}
-    hps['global']['concat_columns'] = [False]
     hps['global']['num_epochs'] = [10]
 
-    imputer.fit_hpo(df_train, hps=hps)
-
-    assert imputer.imputer.data_encoders[0].vectorizer.max_features == 512
-
-
-def test_hpo_feature_specific_overrides_feature_type(test_dir, data_frame):
-    label_col = "label"
-
-    n_samples = 300
-    num_labels = 3
-    seq_len = 4
-
-    # generate some random data
-    df = data_frame(feature_col="string_feature",
-                    label_col=label_col,
-                    num_labels=num_labels,
-                    num_words=seq_len,
-                    n_samples=n_samples)
-
-    df_train, df_test = random_split(df, [.8, .2])
-    output_path = os.path.join(test_dir, "tmp", "real_data_experiment_text_hpo")
-
-    imputer = SimpleImputer(
-        input_columns=[col for col in df.columns if col != label_col],
-        output_column=label_col,
-        output_path=output_path
-    )
-
-    hps = {}
-    hps['string'] = {'max_tokens': [512]}
-    hps['string_feature'] = {'max_tokens': [1024]}
-    hps['global'] = {}
-    hps['global']['concat_columns'] = [False]
-    hps['global']['num_epochs'] = [10]
-
-    imputer.fit_hpo(df_train, hps=hps)
+    imputer.fit_hpo(df, hps=hps)
 
     assert imputer.hpo.results.shape[0] == 1
     assert imputer.imputer.data_encoders[0].vectorizer.max_features == 1024


### PR DESCRIPTION
*Description of changes:*

This PR removes data-type specific hyper parameters as this can cause name clashes with input columns (as it still is true for the `'global'` settings -- and we should address this in another PR). Also, 
without type specific settings, the concat columns hyper parameter is not directly applicable anymore.

The upside of this is a more concise API for the user, for example the user does not have to worry about precedence of the different parameters, and less code for enabling HPO.

Also
- added tests for mixed new-style and legacy `fit_hpo()` parameters (also including legacy only parameters)
- removed deprecated parameters from code examples

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
