### PR TITLE
Consecutive calls to fit resume

### DIFF
--- a/datawig/imputer.py
+++ b/datawig/imputer.py
@@ -258,7 +258,10 @@ class Imputer:
 
         self.__check_data(test_df)
 
-        self.module = self.__build_module(iter_train)
+        # to make consecutive calls to .fit() continue where the previous call finished
+        if self.module is None:
+            self.module = self.__build_module(iter_train)
+
         self.__fit_module(iter_train, iter_test, learning_rate, num_epochs, patience, weight_decay)
 
         # Check whether calibration is needed, if so ompute and set internal parameter
@@ -453,7 +456,6 @@ class Imputer:
                     feature_dict[output_col] = [(token, top_class_weight)]
 
         return feature_dict
-
 
     def __fit_module(self,
                      iter_train: ImputerIterDf,

--- a/datawig/simple_imputer.py
+++ b/datawig/simple_imputer.py
@@ -361,10 +361,12 @@ class SimpleImputer:
             label_column = [CategoricalEncoder(self.output_column, max_tokens=self.num_labels)]
             logger.info("Assuming categorical output column: {}".format(self.output_column))
 
-        self.imputer = Imputer(data_encoders=data_encoders,
-                               data_featurizers=data_columns,
-                               label_encoders=label_column,
-                               output_path=self.output_path)
+        # to make consecutive calls to .fit() continue where the previous call finished
+        if self.imputer is None:
+            self.imputer = Imputer(data_encoders=data_encoders,
+                                   data_featurizers=data_columns,
+                                   label_encoders=label_column,
+                                   output_path=self.output_path)
 
         self.output_path = self.imputer.output_path
 

--- a/test/test_imputer.py
+++ b/test/test_imputer.py
@@ -792,3 +792,27 @@ def test_non_writable_output_path(test_dir, data_frame):
     except Exception as e:
         print(e)
         pytest.fail("This invocation not raise any Exception")
+
+
+def test_fit_resumes(test_dir, data_frame):
+    feature_col, label_col = "feature", "label"
+
+    df = data_frame(feature_col=feature_col,
+                    label_col=label_col)
+
+    imputer = Imputer(
+        data_encoders=[TfIdfEncoder([feature_col])],
+        data_featurizers=[datawig.mxnet_input_symbols.BowFeaturizer(feature_col)],
+        label_encoders=[CategoricalEncoder(label_col)],
+        output_path=test_dir
+    )
+
+    assert imputer.module is None
+
+    imputer.fit(df, num_epochs=20)
+    first_fit_module = imputer.module
+
+    imputer.fit(df, num_epochs=20)
+    second_fit_module = imputer.module
+
+    assert first_fit_module == second_fit_module

--- a/test/test_simple_imputer.py
+++ b/test/test_simple_imputer.py
@@ -837,3 +837,26 @@ def test_hpo_numeric_best_pick(test_dir, data_frame):
     loaded_hpo_run = results.loc[results[feature_col+':max_tokens'] == max_tokens_of_encoder].index[0]
 
     assert best_hpo_run == loaded_hpo_run
+
+
+def test_fit_resumes(test_dir, data_frame):
+    feature_col, label_col = "feature", "label"
+
+    df = data_frame(feature_col=feature_col,
+                    label_col=label_col)
+
+    imputer = SimpleImputer(
+        input_columns=[feature_col],
+        output_column=label_col,
+        output_path=test_dir
+    )
+
+    assert imputer.imputer is None
+
+    imputer.fit(df)
+    first_fit_imputer = imputer.imputer
+
+    imputer.fit(df)
+    second_fit_imputer = imputer.imputer
+
+    assert first_fit_imputer == second_fit_imputer


### PR DESCRIPTION
*Description of changes:*

This PR makes consecutive calls to `.fit()` work as expected, that the training is resumed from the parameters of the previous `.fit()` call.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
