### PR TITLE
Update requirements to avoid numpy version clash

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,4 +2,4 @@ numpy==1.18.0
 scikit-learn[alldeps]==0.22.1
 typing==3.6.6
 pandas==0.25.0
-mxnet==1.4.0
+mxnet>1.4.0


### PR DESCRIPTION
Making this installable despite: 
"mxnet 1.4.0 has requirement numpy<1.15.0,>=1.8.2, but you'll have numpy 1.18.0 which is incompatible."

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
