### PR TITLE
Fix problem to close logger file correctly

### DIFF
--- a/datawig/imputer.py
+++ b/datawig/imputer.py
@@ -169,8 +169,20 @@ class Imputer:
             file_handler.setLevel(level)
             file_handler.setFormatter(log_formatter)
             logger.addHandler(file_handler)
+
         else:
             logger.warning("Could not attach file log handler, {} is not writable.".format(filename))
+
+
+    def __close_filehandlers(self) -> None:
+        """Function to close connection with log file.
+        author: Carlos Moral Rubio."""
+
+        handlers = logger.handlers[:]
+        for handler in handlers:
+            handler.close()
+            logger.removeHandler(handler)
+
 
     def __check_data(self, data_frame: pd.DataFrame) -> None:
         """
@@ -279,6 +291,8 @@ class Imputer:
 
         if self.is_explainable:
             self.__persist_class_prototypes(iter_train, train_df)
+
+        self.__close_filehandlers()
 
         return self
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
I just added a function to close the file handler connected with the logger file. So now, if you use the class Imputer, you will be able to remove all the logs files after the training phase.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
