### PR TITLE
Import ABC from collections.abc for Python 3.10 compatibility

### DIFF
--- a/datawig/utils.py
+++ b/datawig/utils.py
@@ -25,7 +25,7 @@ import random
 import sys
 import time
 import string
-import collections
+import collections.abc
 from typing import Any, List, Tuple, Dict
 
 import mxnet as mx
@@ -66,7 +66,7 @@ def flatten_dict(d: Dict,
     items = []
     for k, v in d.items():
         new_key = parent_key + sep + k if parent_key else k
-        if isinstance(v, collections.MutableMapping):
+        if isinstance(v, collections.abc.MutableMapping):
             items.extend(flatten_dict(v, new_key, sep=sep).items())
         else:
             items.append((new_key, v))


### PR DESCRIPTION
*Description of changes:*

Import ABC from `collections.abc` for Python 3.10 compatibility. Importing from `collections` was deprecated and removed.